### PR TITLE
Allow for different input types in Formatted HTML

### DIFF
--- a/src/main/resources/org/biouno/unochoice/stapler/unochoice/unochoice.js
+++ b/src/main/resources/org/biouno/unochoice/stapler/unochoice/unochoice.js
@@ -815,7 +815,7 @@ var UnoChoice = UnoChoice || (function($) {
         if (e.attr('name') == 'value') {
             value = getElementValue(htmlParameter);
         }  else if (e.prop('tagName') == 'DIV') {
-            var subElements = e.find('input[name="value"]');
+            var subElements = e.find('[name="value"]');
             if (subElements) {
                 var valueBuffer = Array();
                 subElements.each(function() {


### PR DESCRIPTION
Hi,

this tiny change fully supports different input types in the formatted HTML.
Without this change the Formatted HTML option allows to create the various HTML input types dynamically and take a parameter value for the build, but it DOES NOT allow to take the value of such a parameter by a reference to another Reactive Reference Parameters (via Referenced Parameters attribute). 
In effect only the 'input' tag values were reflected. With this change any tag (like select or checkbox will work as well).
