### PR TITLE
Update unochoice.js

### DIFF
--- a/src/main/resources/org/biouno/unochoice/stapler/unochoice/unochoice.js
+++ b/src/main/resources/org/biouno/unochoice/stapler/unochoice/unochoice.js
@@ -847,9 +847,9 @@ var UnoChoice = UnoChoice || (function($) {
         if (e.prop('tagName') == 'SELECT') {
             value = getSelectValues(e);
         } else if (e.attr('type') == 'checkbox' || e.attr('type') == 'radio') {
-            value = (e.attr('checked')== true || e.attr('checked')== 'checked') ? e.attr('value'): '';
+            value = (e.attr('checked') !== undefined) ? e.val(): '';
         } else {
-            value = e.attr('value');
+            value = e.val();
         }
         if (value instanceof Array)
             value = value.toString()


### PR DESCRIPTION
Fixed a bug where they were calling the 'value' attribute on text input elements (which only returns the default value, not the current live value).  Changed `.attr('value')` to the proper call: `.val()`.  Also, the 'checked' attribute simply has to exist for the element to be considered checked, so it is incorrect to only compare it with `checked="checked"`.  Therefore, the following change was made: If attr('checked') is not undefined, then consider the element checked.