### PR TITLE
Temporary solution for the 'Default' parameter value related performance issue.

### DIFF
--- a/src/main/java/org/biouno/unochoice/AbstractScriptableParameter.java
+++ b/src/main/java/org/biouno/unochoice/AbstractScriptableParameter.java
@@ -151,11 +151,22 @@ public abstract class AbstractScriptableParameter extends AbstractUnoChoiceParam
         if (LOGGER.isLoggable(Level.FINE)) {
             LOGGER.entering(AbstractUnoChoiceParameter.class.getName(), "getDefaultParameterValue");
         }
+        /* The commented out approach led into huge performance loss in the Jenkins UI,
+         * when the default parameter values are calculated multiple times, eg by other plugins
+         * (like the inheritance plugin).
+         * Anyway, one should reconsider if this approach is right, as the 'default' value
+         * has rather more static semantic, while the below approach assumes the first element in the list,
+         * which could be rather volatile value, by the nature and dynamic of the script logic behind it.
+         * Maybe the 'default' value should be provided as an UI option, used in case when the script 
+         * returns 'null'.
+         * Until it's redesigned this method will return an empty string.
+         *
+        */
         Object firstElement = "";
-        final Map<Object, Object> choices = getChoices(Collections.<Object, Object> emptyMap());
-        if (choices != null && choices.size() > 0) {
-            firstElement = choices.entrySet().iterator().next().getValue();
-        }
+//        final Map<Object, Object> choices = getChoices(Collections.<Object, Object> emptyMap());
+//        if (choices != null && choices.size() > 0) {
+//            firstElement = choices.entrySet().iterator().next().getValue();
+//        }
         final String name = getName();
         final String value = ObjectUtils.toString(firstElement, ""); // Jenkins doesn't like null parameter values
         final StringParameterValue stringParameterValue = new StringParameterValue(name, value);


### PR DESCRIPTION
Current 'default' parameter value approach leads into huge performance loss in the Jenkins UI,
when the default parameter values are calculated multiple times, eg. by other plugins
(like the inheritance plugin).
Anyway, one should consider if this approach is right, as the semantic of a 'default' value
is rather static, while the current approach assumes the default is the first element in the list, which is rather volatile value, by the nature and dynamic of the script logic behind it.
Maybe the 'default' value should be provided as an UI option, used by Jenkins when the script returns the 'null' value, what d'you think?
Proposed temporary solution is to return an empty string as a default, at least to prevent the performance loss.
The default values have no impact on my use cases, don't know if this would affect any others though.
