### PR TITLE
Fix issue 30545

### DIFF
--- a/src/main/resources/org/biouno/unochoice/stapler/unochoice/unochoice.js
+++ b/src/main/resources/org/biouno/unochoice/stapler/unochoice/unochoice.js
@@ -320,7 +320,8 @@ var UnoChoice = UnoChoice || (function($) {
                                 label.innerHTML = entry;
                             }
                             hiddenValue.setAttribute('json', key);
-                            if(String(JSON.parse(choices)[0][i]).endsWith(':selected')) {
+                            var selectWhich = JSON.parse(choices)[0];
+                            if(String(selectWhich[i]).endsWith(':selected')) {
                             	 hiddenValue.setAttribute('name', 'value');
                             } else {
                             	 hiddenValue.setAttribute('name', '');

--- a/src/main/resources/org/biouno/unochoice/stapler/unochoice/unochoice.js
+++ b/src/main/resources/org/biouno/unochoice/stapler/unochoice/unochoice.js
@@ -320,7 +320,11 @@ var UnoChoice = UnoChoice || (function($) {
                                 label.innerHTML = entry;
                             }
                             hiddenValue.setAttribute('json', key);
-                            hiddenValue.setAttribute('name', '');
+                            if(String(JSON.parse(choices)[0][i]).endsWith(':selected')) {
+                            	 hiddenValue.setAttribute('name', 'value');
+                            } else {
+                            	 hiddenValue.setAttribute('name', '');
+                            }
                             hiddenValue.setAttribute("value", key);
                             hiddenValue.setAttribute("class", _self.getParameterName());
                             hiddenValue.setAttribute("type", "hidden");


### PR DESCRIPTION
Hi, I've found a way to solve issue 30545. ( https://issues.jenkins-ci.org/browse/JENKINS-30545 )

The reason of issue 30545 is when calling "cascadeParameter.update();" in index.jelly in CascadeChoiceParameter, the program doesn't set the name property of a hidden input textField according to which radio button is selected.