### PR TITLE
Removed manually adjusting panel height for checkbox and radio buttons

### DIFF
--- a/src/main/resources/org/biouno/unochoice/common/checkboxContent.jelly
+++ b/src/main/resources/org/biouno/unochoice/common/checkboxContent.jelly
@@ -32,30 +32,4 @@
       </j:forEach>
     </table>
   </div>
-<script type="text/javascript">
-<![CDATA[
-  (function() {
-      var f = function() {
-          var height = 0;
-          var maxCount = ${index};
-          if(maxCount > ${it.visibleItemCount}) {
-              maxCount = ${it.visibleItemCount};
-          }
-
-          if(maxCount > 0 && document.getElementById("ecp_${it.randomName}_0").offsetHeight !=0) {
-              for(var i=0; i< maxCount; i++) {
-                  height += document.getElementById("${id}").offsetHeight + 3;
-              }
-          }
-          else {
-              height = maxCount * 25.5;
-          }
-          height = Math.floor(height);
-          document.getElementById("ecp_${it.randomName}").style.height = height + "px";
-      };
-
-      f();
-  })();
-]]>
-  </script>
 </j:jelly>

--- a/src/main/resources/org/biouno/unochoice/common/radioContent.jelly
+++ b/src/main/resources/org/biouno/unochoice/common/radioContent.jelly
@@ -35,30 +35,4 @@
       </j:forEach>
     </table>
   </div>
-<script type="text/javascript">
-<![CDATA[
-  (function() {
-      var f = function() {
-          var height = 0;
-          var maxCount = ${index};
-          if(maxCount > ${it.visibleItemCount}) {
-              maxCount = ${it.visibleItemCount};
-          }
-
-          if(maxCount > 0 && document.getElementById("${id}").offsetHeight !=0) {
-              for(var i=0; i< maxCount; i++) {
-                  height += document.getElementById("${id}").offsetHeight + 3;
-              }
-          }
-          else {
-              height = maxCount * 25.5;
-          }
-          height = Math.floor(height);
-          document.getElementById("ecp_${it.randomName}").style.height = height + "px";
-      };
-
-      f();
-  })();
-]]>
-</script>
 </j:jelly>

--- a/src/main/resources/org/biouno/unochoice/stapler/unochoice/unochoice.js
+++ b/src/main/resources/org/biouno/unochoice/stapler/unochoice/unochoice.js
@@ -349,10 +349,6 @@ var UnoChoice = UnoChoice || (function($) {
                             _self.getFilterElement().setOriginalArray(originalArray);
                         }
                     } // if (oldSel.className == 'dynamic_checkbox')
-                    /*
-                     * This height is equivalent to setting the number of rows displayed in a select/multiple
-                     */
-                    parameterElement.style.height = '' + (23 * (newValues.length > 10 ? 10 : newValues.length)) + 'px';
                 } // if (oldSel.children.length > 0 && oldSel.children[0].tagName == 'TABLE')
             } // if (oldSel.tagName == 'SELECT') { // else if (oldSel.tagName == 'DIV') {
         });


### PR DESCRIPTION
There was glitches with calculating height of panel for checkbox and radio buttons.
the panel has scrollbars on firefox for linux, because firefox has big checkbox control.
Instead of manually calculating the size of parent panel allow to native layout manager do this.