### PR TITLE
Make Scriptler dependency optional

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,6 +64,7 @@
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scriptler</artifactId>
             <version>2.9</version>
+            <optional>true</optional>
         </dependency>
         <!-- JQuery is included only once -->
         <dependency>

--- a/src/main/java/org/biouno/unochoice/model/ScriptlerScript.java
+++ b/src/main/java/org/biouno/unochoice/model/ScriptlerScript.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.biouno.unochoice.util.Utils;
+import org.jenkinsci.plugins.scriptler.ScriptlerManagement;
 import org.jenkinsci.plugins.scriptler.config.Script;
 import org.jenkinsci.plugins.scriptler.util.ScriptHelper;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
@@ -128,8 +129,12 @@ public class ScriptlerScript extends AbstractScript {
 
     // --- descriptor
 
-    @Extension
+    @Extension(optional = true)
     public static class DescriptorImpl extends ScriptDescriptor {
+        static {
+            // make sure this class fails to load during extension discovery if scriptler isn't present
+            ScriptlerManagement.getScriptlerHomeDirectory();
+        }
         /*
          * (non-Javadoc)
          *


### PR DESCRIPTION
Other than the 'Scriptler mode', the plugin currently looks reasonable from a security POV, as its embedded scripting uses Script Security.

I haven't done a complete check whether this would be enough to restore distribution (there may be other security issues lurking), but I'd be happy to do that if this change is (tentatively) accepted.

@reviewbybees 