### PR TITLE
Optimizing Utils.findProjectByParameterUUID

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <phantomjs.executable>phantomjs</phantomjs.executable>
-        <jenkins.version>2.7.3</jenkins.version>
+        <jenkins.version>2.46.3</jenkins.version>
         <java.level>7</java.level>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,8 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.35</version>
+        <version>3.0</version>
+        <relativePath />
     </parent>
 
     <groupId>org.biouno</groupId>
@@ -109,17 +110,17 @@
             <version>2.0.2-beta</version>
             <scope>test</scope>
         </dependency>
-        <dependency>
+        <dependency> <!-- TODO why is this here? -->
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>sshd</artifactId>
-            <version>1.6</version>
+            <version>1.11</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <!-- placate requireUpperBounds in 2.31+ parent POM -->
             <groupId>org.jenkins-ci.modules</groupId>
             <artifactId>instance-identity</artifactId>
-            <version>1.5.1</version>
+            <version>2.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Observed a Jenkins instance freezing up with this in the support bundle:

```
49761msec elapsed in Handling GET /jenkins/job/…/build from "…" : … ParametersDefinitionProperty/index.jelly CascadeChoiceParameter/index.jelly CascadeChoiceParameter/choiceParameterCommon.jelly CascadeChoiceParameter/selectContent.jelly
	java.lang.String$CaseInsensitiveComparator.compare(String.java:1186)
	java.lang.String.compareToIgnoreCase(String.java:1239)
	hudson.util.CaseInsensitiveComparator.compare(CaseInsensitiveComparator.java:40)
	hudson.util.CaseInsensitiveComparator.compare(CaseInsensitiveComparator.java:34)
	jenkins.model.IdStrategy$CaseInsensitive.compare(IdStrategy.java:176)
	jenkins.model.IdStrategy.equals(IdStrategy.java:90)
	nectar.plugins.rbac.groups.Group.isMatch(Group.java:493)
	nectar.plugins.rbac.groups.Group.isMatch(Group.java:445)
	nectar.plugins.rbac.groups.Group.isMatch(Group.java:382)
	nectar.plugins.rbac.groups.GroupContainerACL.hasPermission(GroupContainerACL.java:196)
	nectar.plugins.rbac.groups.GroupContainerACL._hasPermission(GroupContainerACL.java:123)
	nectar.plugins.rbac.groups.GroupContainerACL.hasPermission(GroupContainerACL.java:76)
	hudson.security.ACL.hasPermission(ACL.java:78)
	hudson.model.AbstractItem.hasPermission(AbstractItem.java:495)
	com.cloudbees.hudson.plugins.folder.AbstractFolder.getItems(AbstractFolder.java:1146)
	hudson.model.Items.getAllItems(Items.java:407)
	hudson.model.Items.getAllItems(Items.java:417)
	hudson.model.Items.getAllItems(Items.java:417)
	hudson.model.Items.getAllItems(Items.java:417)
	hudson.model.Items.getAllItems(Items.java:417)
	hudson.model.Items.getAllItems(Items.java:403)
	jenkins.model.Jenkins.getAllItems(Jenkins.java:1758)
	org.biouno.unochoice.util.Utils.findProjectByParameterUUID(Utils.java:166)
	org.biouno.unochoice.AbstractScriptableParameter.getHelperParameters(AbstractScriptableParameter.java:171)
	org.biouno.unochoice.AbstractScriptableParameter.eval(AbstractScriptableParameter.java:236)
	org.biouno.unochoice.AbstractScriptableParameter.getChoices(AbstractScriptableParameter.java:200)
	org.biouno.unochoice.AbstractScriptableParameter.getChoices(AbstractScriptableParameter.java:188)
```

The method is searching for a project according to some criteria. This stack is pretty silly for two reasons:

* You are performing an access control check, which can be expensive, on every project (or whatever) in the system, before even looking for the match.
* You are sorting the results by name, only to iterate them and look for just one.

2.37+ APIs allow for a more efficient route.

@reviewbybees