### PR TITLE
Patch to solve JENKINS-49260

### DIFF
--- a/src/main/java/org/biouno/unochoice/AbstractScriptableParameter.java
+++ b/src/main/java/org/biouno/unochoice/AbstractScriptableParameter.java
@@ -44,6 +44,8 @@ import hudson.model.AbstractItem;
 import hudson.model.ParameterValue;
 import hudson.model.Project;
 import hudson.model.StringParameterValue;
+import hudson.model.Item;
+import jenkins.model.Jenkins;
 
 /**
  * Base class for parameters with scripts.
@@ -90,6 +92,10 @@ public abstract class AbstractScriptableParameter extends AbstractUnoChoiceParam
      * The project name.
      */
     private final String projectName;
+    /**
+     * The project Full Name (including folder).
+     */
+    private final String projectFullName;
 
     /**
      * Inherited constructor.
@@ -105,6 +111,7 @@ public abstract class AbstractScriptableParameter extends AbstractUnoChoiceParam
         super(name, description);
         this.script = script;
         this.projectName = null;
+        this.projectFullName = null;
     }
 
     /**
@@ -125,6 +132,7 @@ public abstract class AbstractScriptableParameter extends AbstractUnoChoiceParam
         // performance wise approach first.
         final StaplerRequest currentRequest = Stapler.getCurrentRequest();
         String projectName = null;
+        String projectFullName = null;
         if (currentRequest != null) {
             final Ancestor ancestor = currentRequest.findAncestor(AbstractItem.class);
             if (ancestor != null) {
@@ -132,10 +140,12 @@ public abstract class AbstractScriptableParameter extends AbstractUnoChoiceParam
                 if (o instanceof AbstractItem) {
                     final AbstractItem parentItem = (AbstractItem) o;
                     projectName = parentItem.getName();
+                    projectFullName = parentItem.getFullName();
                 }
             }
         }
         this.projectName = projectName;
+        this.projectFullName = projectFullName;
     }
 
     /**
@@ -167,8 +177,11 @@ public abstract class AbstractScriptableParameter extends AbstractUnoChoiceParam
 
         // First, if the project name is set, we then find the project by its name, and inject into the map
         Project<?, ?> project = null;
-        if (StringUtils.isNotBlank(this.projectName)) {
-            // first we try to get the item given its name, which is more efficient
+        if (StringUtils.isNotBlank(this.projectFullName)) {
+            // First try full name if exists
+            project = Jenkins.getItemByFullName(this.projectFullName, Project.class)
+        } else if (StringUtils.isNotBlank(this.projectName)) {
+            // next we try to get the item given its name, which is more efficient
             project = Utils.getProjectByName(this.projectName);
         } else {
             // otherwise, in case we don't have the item name, we iterate looking for a job that uses this UUID

--- a/src/main/java/org/biouno/unochoice/AbstractScriptableParameter.java
+++ b/src/main/java/org/biouno/unochoice/AbstractScriptableParameter.java
@@ -44,7 +44,6 @@ import hudson.model.AbstractItem;
 import hudson.model.ParameterValue;
 import hudson.model.Project;
 import hudson.model.StringParameterValue;
-import hudson.model.Item;
 import jenkins.model.Jenkins;
 
 /**
@@ -179,7 +178,7 @@ public abstract class AbstractScriptableParameter extends AbstractUnoChoiceParam
         Project<?, ?> project = null;
         if (StringUtils.isNotBlank(this.projectFullName)) {
             // First try full name if exists
-            project = Jenkins.getItemByFullName(this.projectFullName, Project.class)
+            project = Jenkins.getInstance().getItemByFullName(this.projectFullName, Project.class);
         } else if (StringUtils.isNotBlank(this.projectName)) {
             // next we try to get the item given its name, which is more efficient
             project = Utils.getProjectByName(this.projectName);

--- a/src/test/java/org/biouno/unochoice/issue49260/TestProjectDifferenceAcrossFolders.java
+++ b/src/test/java/org/biouno/unochoice/issue49260/TestProjectDifferenceAcrossFolders.java
@@ -1,0 +1,111 @@
+/**
+ * Tests for different folders having same Project name. See JENKINS-49260.
+ *
+ * @since 2.2
+ */
+package org.biouno.unochoice.issue49260;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.biouno.unochoice.CascadeChoiceParameter;
+import org.biouno.unochoice.ChoiceParameter;
+import org.biouno.unochoice.model.GroovyScript;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
+import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
+import org.jenkinsci.plugins.scriptsecurity.scripts.languages.GroovyLanguage;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import org.jvnet.hudson.test.MockFolder;
+import org.powermock.api.mockito.PowerMockito;
+import hudson.model.FreeStyleProject;
+import hudson.model.ParametersDefinitionProperty;
+
+import org.kohsuke.stapler.Ancestor;
+import org.kohsuke.stapler.Stapler;
+import org.kohsuke.stapler.StaplerRequest;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
+import org.powermock.modules.junit4.PowerMockRunner;
+import org.junit.runner.RunWith;
+import hudson.model.AbstractItem;
+
+@Issue("JENKINS-49260")
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({StaplerRequest.class, Stapler.class})
+@PowerMockIgnore({"javax.crypto.*" })
+public class TestProjectDifferenceAcrossFolders {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    // LIST script
+    private final String SCRIPT_LIST = "return ['Test', jenkinsProject.getName(), jenkinsProject.getFullName()]";
+    private final String FALLBACK_SCRIPT_LIST = "return ['EMPTY!']";
+
+    private final String PARAMETER_NAME = "my-parameter-name";
+
+    private final String PROJECT_NAME = "MyJenkinsJob";
+    private final String FOLDER_NAME_A = "AAA";
+    private final String FOLDER_NAME_B = "BBB";
+
+    @Before
+    public void setUp() throws Exception {
+        ScriptApproval.get()
+                .preapprove(SCRIPT_LIST, GroovyLanguage.get());
+        ScriptApproval.get()
+                .preapprove(FALLBACK_SCRIPT_LIST, GroovyLanguage.get());
+    }
+
+    @Test
+    public void testProjectAreDifferent() throws IOException {
+        MockFolder folderA = j.createFolder(FOLDER_NAME_A);
+        MockFolder folderB = j.createFolder(FOLDER_NAME_B);
+
+        FreeStyleProject projectA = folderA.createProject(FreeStyleProject.class, PROJECT_NAME);
+        FreeStyleProject projectB = folderB.createProject(FreeStyleProject.class, PROJECT_NAME);
+
+        GroovyScript listScript = new GroovyScript(new SecureGroovyScript(SCRIPT_LIST, Boolean.FALSE, null),
+        new SecureGroovyScript(FALLBACK_SCRIPT_LIST, Boolean.FALSE, null));
+        
+        PowerMockito.mockStatic(Stapler.class);
+
+        StaplerRequest requestA = PowerMockito.mock(StaplerRequest.class);
+        Ancestor ancestorA = PowerMockito.mock(Ancestor.class);
+        PowerMockito.when(Stapler.getCurrentRequest()).thenReturn(requestA);
+        PowerMockito.when(requestA.findAncestor(AbstractItem.class)).thenReturn(ancestorA);
+        PowerMockito.when(ancestorA.getObject()).thenReturn(projectA);
+        ChoiceParameter listParamA = new ChoiceParameter(PARAMETER_NAME, "description...", "random-name-A", listScript,
+                CascadeChoiceParameter.PARAMETER_TYPE_SINGLE_SELECT, false, 1);
+
+        StaplerRequest requestB = PowerMockito.mock(StaplerRequest.class);
+        Ancestor ancestorB = PowerMockito.mock(Ancestor.class);
+        PowerMockito.when(Stapler.getCurrentRequest()).thenReturn(requestB);
+        PowerMockito.when(requestB.findAncestor(AbstractItem.class)).thenReturn(ancestorB);
+        PowerMockito.when(ancestorB.getObject()).thenReturn(projectB);
+        ChoiceParameter listParamB = new ChoiceParameter(PARAMETER_NAME, "description...", "random-name-B", listScript,
+                CascadeChoiceParameter.PARAMETER_TYPE_SINGLE_SELECT, false, 1);
+        
+        ParametersDefinitionProperty paramsDefA = new ParametersDefinitionProperty(listParamA);
+        ParametersDefinitionProperty paramsDefB = new ParametersDefinitionProperty(listParamB);
+
+        projectA.addProperty(paramsDefA);
+        projectB.addProperty(paramsDefB);
+        
+        Map<Object, Object> listSelectionValueA = listParamA.getChoices();
+        Map<Object, Object> listSelectionValueB = listParamB.getChoices();
+
+        // keys and values have the same content when the parameter returns an array...
+        assertTrue("Missing project name for A!", listSelectionValueA.containsKey(PROJECT_NAME));
+        assertTrue("Missing project name for B!", listSelectionValueB.containsKey(PROJECT_NAME));
+
+        // Now, check full name!
+        assertTrue("Missing project full name for A!", listSelectionValueA.containsKey(FOLDER_NAME_A+"/"+PROJECT_NAME));
+        assertTrue("Missing project full name for B!", listSelectionValueB.containsKey(FOLDER_NAME_B+"/"+PROJECT_NAME));
+    }
+}

--- a/src/test/java/org/biouno/unochoice/issue49260/package-info.java
+++ b/src/test/java/org/biouno/unochoice/issue49260/package-info.java
@@ -1,0 +1,7 @@
+
+/**
+ * Tests for different folders having same Project name. See JENKINS-49260.
+ *
+ * @since 2.2
+ */
+package org.biouno.unochoice.issue49260;


### PR DESCRIPTION
Retrieve project using full name instead of only name to take nested folders into account.

See issue JENKINS-49260 (https://issues.jenkins-ci.org/browse/JENKINS-49260) to have more information about the problem.

A test was added, it fails if you comment out the fullname set, using only project "name". I wrote the test based on previous issues-related tests.