### PR TITLE
[JENKINS-61068] set correct value on parambuild page

### DIFF
--- a/src/main/java/org/biouno/unochoice/AbstractScriptableParameter.java
+++ b/src/main/java/org/biouno/unochoice/AbstractScriptableParameter.java
@@ -24,6 +24,7 @@
 
 package org.biouno.unochoice;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -273,15 +274,36 @@ public abstract class AbstractScriptableParameter extends AbstractUnoChoiceParam
         if (LOGGER.isLoggable(Level.FINE)) {
             LOGGER.entering(AbstractUnoChoiceParameter.class.getName(), "getDefaultParameterValue");
         }
-        Object firstElement = "";
-        final Map<Object, Object> choices = getChoices(Collections.<Object, Object> emptyMap());
-        if (choices != null && !choices.isEmpty()) {
-            firstElement = choices.entrySet().iterator().next().getValue();
-        }
         final String name = getName();
-        final String value = ObjectUtils.toString(firstElement, ""); // Jenkins doesn't like null parameter values
+        String defaultValue = findDefaultValue(getChoices(Collections.<Object, Object> emptyMap()));
+        final String value = ObjectUtils.toString(defaultValue, ""); // Jenkins doesn't like null parameter values
         final StringParameterValue stringParameterValue = new StringParameterValue(name, value);
         return stringParameterValue;
+    }
+
+    private static String findDefaultValue(Map<Object, Object> choices) {
+        if (choices == null || choices.isEmpty()) {
+            return null;
+        }
+
+        List<String> defaultValues = new ArrayList<String>();
+        List<Object> values = new ArrayList<Object>(choices.values());
+        for (Object value : values) {
+            String valueText = ObjectUtils.toString(value, "");
+            if (valueText.endsWith(":selected")) {
+                defaultValues.add(valueText.substring(0, valueText.length() - ":selected".length()));
+            }
+        }
+        if (defaultValues.isEmpty()) {
+            return ObjectUtils.toString(values.get(0), null);
+        }
+
+        StringBuilder defaultValuesText = new StringBuilder();
+        for (String value : defaultValues) {
+            defaultValuesText.append(',');
+            defaultValuesText.append(value);
+        }
+        return defaultValuesText.toString().substring(1);
     }
 
     // --- type types

--- a/src/test/java/org/biouno/unochoice/issue61068/TestDefaultValuesOnParamBuildPage.java
+++ b/src/test/java/org/biouno/unochoice/issue61068/TestDefaultValuesOnParamBuildPage.java
@@ -1,0 +1,144 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 Ioannis Moutsatsos, Bruno P. Kinoshita
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.biouno.unochoice.issue61068;
+
+import static org.junit.Assert.assertEquals;
+
+import org.biouno.unochoice.ChoiceParameter;
+import org.biouno.unochoice.model.GroovyScript;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
+import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
+import org.jenkinsci.plugins.scriptsecurity.scripts.languages.GroovyLanguage;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import hudson.model.ParameterValue;
+
+/**
+ * Tests for radio parameter has incorrect default value on parambuild URL. See
+ * JENKINS-61068.
+ *
+ * @since 2.2.3
+ */
+@Issue("JENKINS-61068")
+public class TestDefaultValuesOnParamBuildPage {
+
+    private static final String DEFAULT_FALLBACK_SCRIPT = "return ['EMPTY!']";
+    private static final String PARAMETER_NAME = "my-parameter-name";
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    @Test
+    public void testReturnEmptyWhenNoElementsAreAvailable() {
+        ChoiceParameter parameter = createChoiceParameter(
+                ChoiceParameter.PARAMETER_TYPE_RADIO,
+                "return []"
+        );
+
+        ParameterValue parameterValue = parameter.getDefaultParameterValue();
+
+        assertEquals("Invalid parameter name!", PARAMETER_NAME, parameterValue.getName());
+        assertEquals("Invalid parameter value!", "", parameterValue.getValue());
+    }
+
+    @Test
+    public void testReturnEmptyWhenOnlyEmptyElementIsDefined() {
+        ChoiceParameter parameter = createChoiceParameter(
+                ChoiceParameter.PARAMETER_TYPE_RADIO,
+                "return ['']"
+        );
+
+        ParameterValue parameterValue = parameter.getDefaultParameterValue();
+
+        assertEquals("Invalid parameter name!", PARAMETER_NAME, parameterValue.getName());
+        assertEquals("Invalid parameter value!", "", parameterValue.getValue());
+    }
+
+    @Test
+    public void testReturnFirstElementWhenSelectedIsNotSet() {
+        ChoiceParameter parameter = createChoiceParameter(
+                ChoiceParameter.PARAMETER_TYPE_RADIO,
+                "return ['A', 'B', 'C', 'D']"
+        );
+
+        ParameterValue parameterValue = parameter.getDefaultParameterValue();
+
+        assertEquals("Invalid parameter name!", PARAMETER_NAME, parameterValue.getName());
+        assertEquals("Invalid parameter value!", "A", parameterValue.getValue());
+    }
+
+    @Test
+    public void testReturnSelectedElement() {
+        ChoiceParameter parameter = createChoiceParameter(
+                ChoiceParameter.PARAMETER_TYPE_RADIO,
+                "return ['A', 'B', 'C:selected', 'D']"
+        );
+
+        ParameterValue parameterValue = parameter.getDefaultParameterValue();
+
+        assertEquals("Invalid parameter name!", PARAMETER_NAME, parameterValue.getName());
+        assertEquals("Invalid parameter value!", "C", parameterValue.getValue());
+    }
+
+    @Test
+    public void testReturnSelectedElements() {
+        ChoiceParameter parameter = createChoiceParameter(
+                ChoiceParameter.PARAMETER_TYPE_CHECK_BOX,
+                "return ['A', 'B:selected', 'C', 'D:selected']"
+        );
+
+        ParameterValue parameterValue = parameter.getDefaultParameterValue();
+
+        assertEquals("Invalid parameter name!", PARAMETER_NAME, parameterValue.getName());
+        assertEquals("Invalid parameter value!", "B,D", parameterValue.getValue());
+    }
+
+    @Test
+    public void testReturnSelectedEmptyElement() {
+        ChoiceParameter parameter = createChoiceParameter(
+                ChoiceParameter.PARAMETER_TYPE_RADIO,
+                "return ['A', 'B', ':selected', 'D']"
+        );
+
+        ParameterValue parameterValue = parameter.getDefaultParameterValue();
+
+        assertEquals("Invalid parameter name!", PARAMETER_NAME, parameterValue.getName());
+        assertEquals("Invalid parameter value!", "", parameterValue.getValue());
+    }
+
+    private static final ChoiceParameter createChoiceParameter(String type, String script) {
+        ScriptApproval.get().preapprove(script, GroovyLanguage.get());
+        ScriptApproval.get().preapprove(DEFAULT_FALLBACK_SCRIPT, GroovyLanguage.get());
+
+        GroovyScript groovyScript = new GroovyScript(
+                new SecureGroovyScript(script, Boolean.FALSE, null),
+                new SecureGroovyScript(DEFAULT_FALLBACK_SCRIPT, Boolean.FALSE, null)
+        );
+        return new ChoiceParameter(PARAMETER_NAME, "description", "random-name1", groovyScript, type, true, 1);
+    }
+}

--- a/src/test/java/org/biouno/unochoice/issue61068/package-info.java
+++ b/src/test/java/org/biouno/unochoice/issue61068/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 Ioannis Moutsatsos, Bruno P. Kinoshita
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * Tests for radio parameter has incorrect default value on parambuild URL. See JENKINS-61068.
+ *
+ * @since 2.2.3
+ */
+package org.biouno.unochoice.issue61068;


### PR DESCRIPTION
getDefaultParameterValue is used to get value on parambuild and buildWithParameters urls (trigger build). Those pages use text boxes to represent Active Choices parameters.

The method should respect users configuration and return values with ":selected" suffix. If no value contains the suffix, it should return the first element (backward compatibility).