### PR TITLE
[JENKINS-61751] let :disabled and :deleted at the same time

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,17 @@ selection when the parameter UI control is rendered.
 
 ![](https://wiki.jenkins.io/download/attachments/74875908/AC_cb01_param.gif?version=1&modificationDate=1435868473000&api=v2)
 
+#### Making 'Disabled' selections
+
+You also can **define disabled selections** by adding the suffix;
+**:disabled** to the element(s) you want to be disabled.
+In the example below, we will make various elements to be disabled and
+unmutable.
+
+**IMAGE HERE**
+
+As you can see, both **:selected** and **:disabled** can be specified at the same time.
+
 We credit the developers of the [Dynamic Parameter
 plugin](https://wiki.jenkins-ci.org/display/JENKINS/Dynamic+Parameter+Plug-in) with
 some of the initial concepts and code on which Active Choices was

--- a/src/main/java/org/biouno/unochoice/AbstractScriptableParameter.java
+++ b/src/main/java/org/biouno/unochoice/AbstractScriptableParameter.java
@@ -291,12 +291,7 @@ public abstract class AbstractScriptableParameter extends AbstractUnoChoiceParam
         for (Object value : values) {
             String valueText = ObjectUtils.toString(value, "");
             if (Utils.isSelected(valueText)) {
-                if (Utils.isDisabled(valueText)) {
-                  defaultValues.add(Utils.escapeSelectedAndDisabled(valueText));
-                }
-                else {
-                  defaultValues.add(Utils.escapeSelected(valueText));
-                }
+                defaultValues.add(Utils.escapeSelectedAndDisabled(valueText));
             }
         }
         if (defaultValues.isEmpty()) {

--- a/src/main/java/org/biouno/unochoice/AbstractScriptableParameter.java
+++ b/src/main/java/org/biouno/unochoice/AbstractScriptableParameter.java
@@ -291,7 +291,12 @@ public abstract class AbstractScriptableParameter extends AbstractUnoChoiceParam
         for (Object value : values) {
             String valueText = ObjectUtils.toString(value, "");
             if (Utils.isSelected(valueText)) {
-                defaultValues.add(Utils.escapeSelected(valueText));
+                if (Utils.isDisabled(valueText)) {
+                  defaultValues.add(Utils.escapeSelectedAndDisabled(valueText));
+                }
+                else {
+                  defaultValues.add(Utils.escapeSelected(valueText));
+                }
             }
         }
         if (defaultValues.isEmpty()) {

--- a/src/main/java/org/biouno/unochoice/AbstractScriptableParameter.java
+++ b/src/main/java/org/biouno/unochoice/AbstractScriptableParameter.java
@@ -183,7 +183,7 @@ public abstract class AbstractScriptableParameter extends AbstractUnoChoiceParam
         } else if (StringUtils.isNotBlank(this.projectName)) {
             // next we try to get the item given its name, which is more efficient
             project = Utils.getProjectByName(this.projectName);
-        } 
+        }
         // Last chance, if we were unable to get project from name and full name, try uuid
         if (project == null) {
             // otherwise, in case we don't have the item name, we iterate looking for a job that uses this UUID
@@ -290,8 +290,8 @@ public abstract class AbstractScriptableParameter extends AbstractUnoChoiceParam
         List<Object> values = new ArrayList<Object>(choices.values());
         for (Object value : values) {
             String valueText = ObjectUtils.toString(value, "");
-            if (valueText.endsWith(":selected")) {
-                defaultValues.add(valueText.substring(0, valueText.length() - ":selected".length()));
+            if (Utils.isSelected(valueText)) {
+                defaultValues.add(Utils.escapeSelected(valueText));
             }
         }
         if (defaultValues.isEmpty()) {

--- a/src/main/java/org/biouno/unochoice/util/Utils.java
+++ b/src/main/java/org/biouno/unochoice/util/Utils.java
@@ -96,7 +96,7 @@ public class Utils {
         if (obj == null)
             return false;
         final String text = obj.toString();
-        return StringUtils.isNotBlank(text) && text.contains(":selected");
+        return StringUtils.isNotBlank(text) && (text.endsWith(":selected") || text.endsWith(":selected:disabled"));
     }
 
     /**
@@ -112,7 +112,7 @@ public class Utils {
         if (StringUtils.isBlank(text))
             return "";
         if (isSelected(text))
-            return text.replace(":selected","");
+            return text.replaceAll(":selected$", "").replaceAll(":selected:disabled$", ":disabled");
         return text;
     }
 
@@ -127,7 +127,7 @@ public class Utils {
         if (obj == null)
             return false;
         final String text = obj.toString();
-        return StringUtils.isNotBlank(text) && text.contains(":disabled");
+        return StringUtils.isNotBlank(text) && (text.endsWith(":disabled") || text.endsWith(":disabled:selected"));
     }
 
     /**
@@ -143,7 +143,7 @@ public class Utils {
         if (StringUtils.isBlank(text))
             return "";
         if (isDisabled(text))
-            return text.replace(":disabled","");
+            return text.replaceAll(":disabled$", "").replaceAll(":disabled:selected$", ":selected");
         return text;
     }
 

--- a/src/main/java/org/biouno/unochoice/util/Utils.java
+++ b/src/main/java/org/biouno/unochoice/util/Utils.java
@@ -148,6 +148,23 @@ public class Utils {
     }
 
     /**
+     * Escapes the parameter value, removing the :selected and :disabled suffixes.
+     *
+     * @param obj parameter value
+     * @return escaped parameter value
+     */
+    public static @Nonnull String escapeSelectedAndDisabled(@Nullable Object obj) {
+        if (obj == null)
+            return "";
+        final String text = obj.toString();
+        if (StringUtils.isBlank(text))
+            return "";
+        if (isSelected(text) || isDisabled(text))
+            return escapeSelected(escapeDisabled(text));
+        return text;
+    }
+
+    /**
      * Creates a random parameter name.
      *
      * @param prefix parameter prefix

--- a/src/main/java/org/biouno/unochoice/util/Utils.java
+++ b/src/main/java/org/biouno/unochoice/util/Utils.java
@@ -96,7 +96,7 @@ public class Utils {
         if (obj == null)
             return false;
         final String text = obj.toString();
-        return StringUtils.isNotBlank(text) && text.endsWith(":selected");
+        return StringUtils.isNotBlank(text) && text.contains(":selected");
     }
 
     /**
@@ -112,7 +112,7 @@ public class Utils {
         if (StringUtils.isBlank(text))
             return "";
         if (isSelected(text))
-            return text.substring(0, text.indexOf(":selected"));
+            return text.replace(":selected","");
         return text;
     }
 
@@ -127,7 +127,7 @@ public class Utils {
         if (obj == null)
             return false;
         final String text = obj.toString();
-        return StringUtils.isNotBlank(text) && text.endsWith(":disabled");
+        return StringUtils.isNotBlank(text) && text.contains(":disabled");
     }
 
     /**
@@ -143,7 +143,7 @@ public class Utils {
         if (StringUtils.isBlank(text))
             return "";
         if (isDisabled(text))
-            return text.substring(0, text.indexOf(":disabled"));
+            return text.replace(":disabled","");
         return text;
     }
 

--- a/src/main/resources/org/biouno/unochoice/common/checkboxContent.jelly
+++ b/src/main/resources/org/biouno/unochoice/common/checkboxContent.jelly
@@ -28,17 +28,29 @@
         <tr id="ecp_${it.randomName}_${index}" style="white-space:nowrap">
           <td>
             <j:choose>
+              <j:when test="${selected &amp;&amp; disabled}">
+                <j:invokeStatic className="org.biouno.unochoice.util.Utils" method="escapeDisabled" var="escapedAndDisabledValue">
+                  <j:arg type="java.lang.Object" value="${escapedValue}" />
+                </j:invokeStatic>
+                <j:invokeStatic className="org.biouno.unochoice.util.Utils" method="escapeDisabled" var="escapedAndDisabledKey">
+                  <j:arg type="java.lang.Object" value="${escapedKey}" />
+                </j:invokeStatic>
+                <input disabled="${disabled}" json="${escapedAndDisabledKey}" name="value" value="${escapedAndDisabledKey}" class=" " type="checkbox" title="${escapedAndDisabledValue}" alt="${escapedAndDisabledValue}" checked="true" />
+                <label class="attach-previous" title="${escapedAndDisabledValue}">${escapedAndDisabledValue}</label>
+              </j:when>
               <j:when test="${selected}">
                 <input json="${escapedKey}" name="value" value="${escapedKey}" class=" " type="checkbox" title="${escapedValue}" alt="${escapedValue}" checked="true" />
+                <label class="attach-previous" title="${escapedValue}">${escapedValue}</label>
               </j:when>
               <j:when test="${disabled}">
                 <input disabled="${disabled}" json="${escapedDisabledKey}" name="value" value="${escapedDisabledKey}" class=" " type="checkbox" title="${escapedDisabledValue}" alt="${escapedDisabledValue}"  />
+                <label class="attach-previous" title="${escapedDisabledValue}">${escapedDisabledValue}</label>
               </j:when>
               <j:otherwise>
                 <input json="${escapedKey}" name="value" value="${escapedKey}" class=" " type="checkbox" title="${escapedValue}" alt="${escapedValue}"  />
+                <label class="attach-previous" title="${escapedValue}">${escapedValue}</label>
               </j:otherwise>
             </j:choose>
-            <label class="attach-previous" title="${escapedValue}">${escapedValue}</label>
           </td>
         </tr>
         <j:set var="index" value="${index + 1}"/>

--- a/src/main/resources/org/biouno/unochoice/common/radioContent.jelly
+++ b/src/main/resources/org/biouno/unochoice/common/radioContent.jelly
@@ -28,6 +28,17 @@
         <tr id="tbl_tr_ecp_${it.randomName}" style="white-space:nowrap">
           <td>
             <j:choose>
+              <j:when test="${selected &amp;&amp; disabled}">
+                <j:invokeStatic className="org.biouno.unochoice.util.Utils" method="escapeDisabled" var="escapedAndDisabledValue">
+                  <j:arg type="java.lang.Object" value="${escapedValue}" />
+                </j:invokeStatic>
+                <j:invokeStatic className="org.biouno.unochoice.util.Utils" method="escapeDisabled" var="escapedAndDisabledKey">
+                  <j:arg type="java.lang.Object" value="${escapedKey}" />
+                </j:invokeStatic>
+                <input disabled="${disabled}" json="${escapedAndDisabledKey}" alt="${escapedAndDisabledValue}" otherid="${id}" checked="checked" name="${it.name}" value="${escapedAndDisabledKey}" class=" " type="radio" onchange="UnoChoice.fakeSelectRadioButton(&quot;${it.name}&quot;, &quot;${id}&quot;)" />
+                <label class="attach-previous">${escapedAndDisabledValue}</label>
+                <input disabled="${disabled}" json="${escapedAndDisabledKey}" name="value" value="${escapedAndDisabledKey}" class="${it.name}" type="hidden" id="${id}" title="${escapedAndDisabledValue}" />
+              </j:when>
               <j:when test="${selected}">
                 <input json="${escapedKey}" alt="${escapedValue}" otherid="${id}" checked="checked" name="${it.name}" value="${escapedKey}" class=" " type="radio" onchange="UnoChoice.fakeSelectRadioButton(&quot;${it.name}&quot;, &quot;${id}&quot;)" />
                 <label class="attach-previous">${escapedValue}</label>

--- a/src/main/resources/org/biouno/unochoice/common/selectContent.jelly
+++ b/src/main/resources/org/biouno/unochoice/common/selectContent.jelly
@@ -25,8 +25,17 @@
         <j:arg type="java.lang.Object" value="${iter.key}" />
     </j:invokeStatic>
     <j:choose>
+        <j:when test="${selected &amp;&amp; disabled}">
+            <j:invokeStatic className="org.biouno.unochoice.util.Utils" method="escapeDisabled" var="escapedAndDisabledValue">
+                <j:arg type="java.lang.Object" value="${escapedValue}" />
+            </j:invokeStatic>
+            <j:invokeStatic className="org.biouno.unochoice.util.Utils" method="escapeDisabled" var="escapedAndDisabledKey">
+                <j:arg type="java.lang.Object" value="${escapedKey}" />
+            </j:invokeStatic>
+            <option selected="${selected}" disabled="${disabled}" value="${escapedAndDisabledKey}">${escapedAndDisabledValue}</option>
+        </j:when>
         <j:when test="${selected}">
-            <f:option selected="${selected}" value="${escapedKey}">${escapedValue}</f:option>
+            <option selected="${selected}" value="${escapedKey}">${escapedValue}</option>
         </j:when>
         <j:when test="${disabled}">
             <option disabled="${disabled}" value="${escapedDisabledKey}">${escapedDisabledValue}</option>

--- a/src/main/resources/org/biouno/unochoice/stapler/unochoice/unochoice.js
+++ b/src/main/resources/org/biouno/unochoice/stapler/unochoice/unochoice.js
@@ -165,20 +165,20 @@ var UnoChoice = UnoChoice || (function($) {
             // we want to remove these suffixes
             for (var i = 0; i < newValues.length; i++) {
                 var newValue = String(newValues[i]);
-                if (newValue && newValue.contains(':selected')) {
+                if (newValue && (newValue.endsWith(':selected') || newValue.endsWith(':selected:disabled'))) {
                     selectedElements.push(i);
-                    newValues[i] = newValues[i].replace(':selected','');
+                    newValues[i] = newValues[i].replace(/:selected$/,'').replace(/:selected:disabled$/, ':disabled');
                 }
-                if (newValue && newValue.contains(':disabled')) {
+                if (newValue && (newValue.endsWith(':disabled') || newValue.endsWith(':disabled:selected'))) {
                     disabledElements.push(i);
-                    newValues[i] = newValues[i].replace(':disabled','');
+                    newValues[i] = newValues[i].replace(/:disabled$/,'').replace(/:disabled:selected$/, ':selected');
                 }
                 var newKey = String(newKeys[i]);
-                if (newKey && typeof newKey === "string" && newKey.contains(':selected')) {
-                    newKeys[i] = newKeys[i].replace(':selected','');
+                if (newKey && typeof newKey === "string" && (newKey.endsWith(':selected') || newKey.endsWith(':selected:disabled'))) {
+                    newKeys[i] = newKeys[i].replace(/:selected$/,'').replace(/:selected:disabled$/,':disabled');
                 }
-                if (newKey && typeof newKey === "string" && newKey.contains(':disabled')) {
-                    newKeys[i] = newKeys[i].replace(':disabled','');
+                if (newKey && typeof newKey === "string" && (newKey.endsWith(':disabled') || newKey.endsWith(':disabled:selected'))) {
+                    newKeys[i] = newKeys[i].replace(/:disabled$/,'').replace(/:disabled:selected$/,':selected');
                 }
             }
             if (_self.getFilterElement()) {

--- a/src/main/resources/org/biouno/unochoice/stapler/unochoice/unochoice.js
+++ b/src/main/resources/org/biouno/unochoice/stapler/unochoice/unochoice.js
@@ -161,24 +161,24 @@ var UnoChoice = UnoChoice || (function($) {
             var selectedElements = [];
             var disabledElements = [];
             // filter selected and disabled elements and create a matrix for selection and disabled
-            // some elements may have key or values with the suffixes :selected and :disabled
+            // some elements may have key or values with the suffixes :selected and/or :disabled
             // we want to remove these suffixes
             for (var i = 0; i < newValues.length; i++) {
                 var newValue = String(newValues[i]);
-                if (newValue && newValue.endsWith(':selected')) {
+                if (newValue && newValue.contains(':selected')) {
                     selectedElements.push(i);
-                    newValues[i] = newValues[i].substring(0, newValue.indexOf(':selected'));
+                    newValues[i] = newValues[i].replace(':selected','');
                 }
-                if (newValue && newValue.endsWith(':disabled')) {
+                if (newValue && newValue.contains(':disabled')) {
                     disabledElements.push(i);
-                    newValues[i] = newValues[i].substring(0, newValue.indexOf(':disabled'));
+                    newValues[i] = newValues[i].replace(':disabled','');
                 }
                 var newKey = String(newKeys[i]);
-                if (newKey && typeof newKey === "string" && newKey.endsWith(':selected')) {
-                    newKeys[i] = newKeys[i].substring(0, newKey.indexOf(':selected'));
+                if (newKey && typeof newKey === "string" && newKey.contains(':selected')) {
+                    newKeys[i] = newKeys[i].replace(':selected','');
                 }
-                if (newKey && typeof newKey == "string" && newKey.endsWith(':disabled')) {
-                    newKeys[i] = newKeys[i].substring(0, newKey.indexOf(':disabled'));
+                if (newKey && typeof newKey === "string" && newKey.contains(':disabled')) {
+                    newKeys[i] = newKeys[i].replace(':disabled','');
                 }
             }
             if (_self.getFilterElement()) {

--- a/src/test/java/org/biouno/unochoice/issue61068/TestDefaultValuesOnParamBuildPage.java
+++ b/src/test/java/org/biouno/unochoice/issue61068/TestDefaultValuesOnParamBuildPage.java
@@ -131,6 +131,19 @@ public class TestDefaultValuesOnParamBuildPage {
         assertEquals("Invalid parameter value!", "", parameterValue.getValue());
     }
 
+    @Test
+    public void testAllSuffixesAreTrimmed() {
+        ChoiceParameter parameter = createChoiceParameter(
+                ChoiceParameter.PARAMETER_TYPE_CHECK_BOX,
+                "return ['A:selected:disabled', 'B:disabled:selected', 'C', 'D:selected']"
+        );
+
+        ParameterValue parameterValue = parameter.getDefaultParameterValue();
+
+        assertEquals("Invalid parameter name!", PARAMETER_NAME, parameterValue.getName());
+        assertEquals("Invalid parameter value!", "A,B,D", parameterValue.getValue());
+    }
+
     private static final ChoiceParameter createChoiceParameter(String type, String script) {
         ScriptApproval.get().preapprove(script, GroovyLanguage.get());
         ScriptApproval.get().preapprove(DEFAULT_FALLBACK_SCRIPT, GroovyLanguage.get());

--- a/src/test/java/org/biouno/unochoice/issue61068/TestDefaultValuesOnParamBuildPage.java
+++ b/src/test/java/org/biouno/unochoice/issue61068/TestDefaultValuesOnParamBuildPage.java
@@ -96,7 +96,7 @@ public class TestDefaultValuesOnParamBuildPage {
     public void testReturnSelectedElement() {
         ChoiceParameter parameter = createChoiceParameter(
                 ChoiceParameter.PARAMETER_TYPE_RADIO,
-                "return ['A', 'B', 'C:selected', 'D']"
+                "return ['A', 'B', 'C:selected', 'D', 'E:disabled']"
         );
 
         ParameterValue parameterValue = parameter.getDefaultParameterValue();
@@ -109,7 +109,7 @@ public class TestDefaultValuesOnParamBuildPage {
     public void testReturnSelectedElements() {
         ChoiceParameter parameter = createChoiceParameter(
                 ChoiceParameter.PARAMETER_TYPE_CHECK_BOX,
-                "return ['A', 'B:selected', 'C', 'D:selected']"
+                "return ['A', 'B:selected', 'C', 'D:selected', 'E:disabled']"
         );
 
         ParameterValue parameterValue = parameter.getDefaultParameterValue();
@@ -122,7 +122,7 @@ public class TestDefaultValuesOnParamBuildPage {
     public void testReturnSelectedEmptyElement() {
         ChoiceParameter parameter = createChoiceParameter(
                 ChoiceParameter.PARAMETER_TYPE_RADIO,
-                "return ['A', 'B', ':selected', 'D']"
+                "return ['A', 'B', ':selected', 'D', 'E:disabled']"
         );
 
         ParameterValue parameterValue = parameter.getDefaultParameterValue();

--- a/src/test/java/org/biouno/unochoice/util/TestUtils.java
+++ b/src/test/java/org/biouno/unochoice/util/TestUtils.java
@@ -139,6 +139,39 @@ public class TestUtils {
     }
 
     @Test
+    public void testEscapeSelectedAndDisabled() {
+        String escaped = Utils.escapeSelectedAndDisabled(null);
+        assertEquals("", escaped);
+
+        escaped = Utils.escapeSelectedAndDisabled("");
+        assertEquals("", escaped);
+
+        escaped = Utils.escapeSelectedAndDisabled("a:disabled");
+        assertEquals("a", escaped);
+
+        escaped = Utils.escapeSelectedAndDisabled("a:selected:disabled");
+        assertEquals("a", escaped);
+
+        escaped = Utils.escapeSelectedAndDisabled("a:disabled:selected");
+        assertEquals("a", escaped);
+
+        escaped = Utils.escapeSelectedAndDisabled("a:selected example");
+        assertEquals("a:selected example", escaped);
+
+        escaped = Utils.escapeSelectedAndDisabled("a:disabled example");
+        assertEquals("a:disabled example", escaped);
+
+        escaped = Utils.escapeSelectedAndDisabled("a:selected:disabled example");
+        assertEquals("a:selected:disabled example", escaped);
+
+        escaped = Utils.escapeSelectedAndDisabled("a:disabled:selected example");
+        assertEquals("a:disabled:selected example", escaped);
+
+        escaped = Utils.escapeSelectedAndDisabled("a");
+        assertEquals("a", escaped);
+    }
+
+    @Test
     public void testRandomParameterName() {
         String paramName = Utils.createRandomParameterName("test", "param");
         assertNotNull(paramName);

--- a/src/test/java/org/biouno/unochoice/util/TestUtils.java
+++ b/src/test/java/org/biouno/unochoice/util/TestUtils.java
@@ -76,6 +76,7 @@ public class TestUtils {
         assertFalse(Utils.isSelected(null));
         assertFalse(Utils.isSelected(""));
         assertFalse(Utils.isSelected("a"));
+        assertFalse(Utils.isSelected("a:selected example"));
     }
 
     @Test
@@ -95,6 +96,9 @@ public class TestUtils {
         escaped = Utils.escapeSelected("a:disabled:selected");
         assertEquals("a:disabled", escaped);
 
+        escaped = Utils.escapeSelected("a:selected example");
+        assertEquals("a:selected example", escaped);
+
         escaped = Utils.escapeSelected("a");
         assertEquals("a", escaped);
     }
@@ -107,6 +111,7 @@ public class TestUtils {
         assertFalse(Utils.isDisabled(null));
         assertFalse(Utils.isDisabled(""));
         assertFalse(Utils.isDisabled("a"));
+        assertFalse(Utils.isDisabled("a:disabled example"));
     }
 
     @Test
@@ -125,6 +130,9 @@ public class TestUtils {
 
         escaped = Utils.escapeDisabled("a:disabled:selected");
         assertEquals("a:selected", escaped);
+
+        escaped = Utils.escapeDisabled("a:disabled example");
+        assertEquals("a:disabled example", escaped);
 
         escaped = Utils.escapeDisabled("a");
         assertEquals("a", escaped);

--- a/src/test/java/org/biouno/unochoice/util/TestUtils.java
+++ b/src/test/java/org/biouno/unochoice/util/TestUtils.java
@@ -71,6 +71,8 @@ public class TestUtils {
     @Test
     public void testIsSelected() {
         assertTrue(Utils.isSelected("a:selected"));
+        assertTrue(Utils.isSelected("a:selected:disabled"));
+        assertTrue(Utils.isSelected("a:disabled:selected"));
         assertFalse(Utils.isSelected(null));
         assertFalse(Utils.isSelected(""));
         assertFalse(Utils.isSelected("a"));
@@ -87,6 +89,12 @@ public class TestUtils {
         escaped = Utils.escapeSelected("a:selected");
         assertEquals("a", escaped);
 
+        escaped = Utils.escapeSelected("a:selected:disabled");
+        assertEquals("a:disabled", escaped);
+
+        escaped = Utils.escapeSelected("a:disabled:selected");
+        assertEquals("a:disabled", escaped);
+
         escaped = Utils.escapeSelected("a");
         assertEquals("a", escaped);
     }
@@ -94,6 +102,8 @@ public class TestUtils {
     @Test
     public void testIsDisabled() {
         assertTrue(Utils.isDisabled("a:disabled"));
+        assertTrue(Utils.isDisabled("a:selected:disabled"));
+        assertTrue(Utils.isDisabled("a:disabled:selected"));
         assertFalse(Utils.isDisabled(null));
         assertFalse(Utils.isDisabled(""));
         assertFalse(Utils.isDisabled("a"));
@@ -109,6 +119,12 @@ public class TestUtils {
 
         escaped = Utils.escapeDisabled("a:disabled");
         assertEquals("a", escaped);
+
+        escaped = Utils.escapeDisabled("a:selected:disabled");
+        assertEquals("a:selected", escaped);
+
+        escaped = Utils.escapeDisabled("a:disabled:selected");
+        assertEquals("a:selected", escaped);
 
         escaped = Utils.escapeDisabled("a");
         assertEquals("a", escaped);


### PR DESCRIPTION
Asked for a new capability derived from https://github.com/jenkinsci/active-choices-plugin/pull/25#issuecomment-601925184.

Allow to disable and select any (select option|radio|checkbox) with :disable and/or :selected