### PR TITLE
[JENKINS-62317]: Upgrade dependencies pre 2.3 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -615,6 +615,7 @@ via [@tupilabs](https://twitter.com/tupilabs)
 1. [JENKINS-61068](https://issues.jenkins-ci.org/browse/JENKINS-61068): Active Choices radio parameter has incorrect default value on parambuild URL. Fixed by Adam Gabryś in [pr/32](https://github.com/jenkinsci/active-choices-plugin/pull/32) (thanks!).
 2. [JENKINS-61751](https://issues.jenkins-ci.org/browse/JENKINS-61751): let :disabled and :deleted at the same (thanks to @ivarmu)
 3. [JENKINS-62317](https://issues.jenkins-ci.org/browse/JENKINS-62317): Upgrade dependencies pre 2.3 release (Jenkins LTS 2.204 now, Java 8, script-security 1.72, antisamy-markup-formatter 2.0, no more powermockito in tests, fixing spot bugs issues)
+4. [JENKINS-39742](https://issues.jenkins-ci.org/browse/JENKINS-39742): Active Choice Plugin should honor ParameterDefinition serializability (was: Active Choice Plugin in Pipelines throw NotSerializableException)
 
 ##### Version 2.2 (2019/09/13)
 

--- a/README.md
+++ b/README.md
@@ -614,6 +614,7 @@ via [@tupilabs](https://twitter.com/tupilabs)
 
 1. [JENKINS-61068](https://issues.jenkins-ci.org/browse/JENKINS-61068): Active Choices radio parameter has incorrect default value on parambuild URL. Fixed by Adam Gabryś in [pr/32](https://github.com/jenkinsci/active-choices-plugin/pull/32) (thanks!).
 2. [JENKINS-61751](https://issues.jenkins-ci.org/browse/JENKINS-61751): let :disabled and :deleted at the same (thanks to @ivarmu)
+3. [JENKINS-62317](https://issues.jenkins-ci.org/browse/JENKINS-62317): Upgrade dependencies pre 2.3 release (Jenkins LTS 2.204 now, Java 8, script-security 1.72, antisamy-markup-formatter 2.0, no more powermockito in tests, fixing spot bugs issues)
 
 ##### Version 2.2 (2019/09/13)
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,6 +59,18 @@
         </developer>
     </developers>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.jenkins.tools.bom</groupId>
+                <artifactId>bom-2.204.x</artifactId>
+                <version>9</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <!-- Scriptler is used to eval Groovy parameters -->
         <dependency>
@@ -83,7 +95,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.50</version>
+            <version>1.66</version>
         </dependency>
         <!-- escaping output of dynamic reference parameters -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -6,13 +6,13 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>3.0</version>
+        <version>4.1</version>
         <relativePath />
     </parent>
 
     <groupId>org.biouno</groupId>
     <artifactId>uno-choice</artifactId>
-    <version>2.2.3-SNAPSHOT</version>
+    <version>2.3-SNAPSHOT</version>
     <packaging>hpi</packaging>
 
     <name>Active Choices Plug-in</name>
@@ -36,8 +36,8 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <phantomjs.executable>phantomjs</phantomjs.executable>
-        <jenkins.version>2.60.3</jenkins.version>
-        <java.level>7</java.level>
+        <jenkins.version>2.204.1</jenkins.version>
+        <java.level>8</java.level>
     </properties>
 
     <scm>
@@ -64,7 +64,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>scriptler</artifactId>
-            <version>2.9</version>
+            <version>3.1</version>
             <optional>true</optional>
         </dependency>
         <!-- JQuery is included only once -->
@@ -83,57 +83,19 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.39</version>
+            <version>1.50</version>
         </dependency>
         <!-- escaping output of dynamic reference parameters -->
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>antisamy-markup-formatter</artifactId>
-            <version>1.5</version>
+            <version>2.0</version>
         </dependency>
         <!-- testing -->
         <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-module-junit4</artifactId>
-            <version>1.6.5</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.powermock</groupId>
-            <artifactId>powermock-api-mockito</artifactId>
-            <version>1.6.5</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>2.0.2-beta</version>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
-        </dependency>
-        <dependency> <!-- TODO why is this here? -->
-            <groupId>org.jenkins-ci.modules</groupId>
-            <artifactId>sshd</artifactId>
-            <version>1.11</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <!-- placate requireUpperBounds in 2.31+ parent POM -->
-            <groupId>org.jenkins-ci.modules</groupId>
-            <artifactId>instance-identity</artifactId>
-            <version>2.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <!-- placate requireUpperBounds in 2.31+ parent POM -->
-            <groupId>org.jenkins-ci.modules</groupId>
-            <artifactId>ssh-cli-auth</artifactId>
-            <version>1.4</version>
-        </dependency>
-        <dependency>
-            <!-- placate requireUpperBounds in 2.31+ parent POM -->
-            <groupId>org.objenesis</groupId>
-            <artifactId>objenesis</artifactId>
-            <version>2.2</version>
         </dependency>
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>script-security</artifactId>
-            <version>1.66</version>
+            <version>1.72</version>
         </dependency>
         <!-- escaping output of dynamic reference parameters -->
         <dependency>

--- a/src/main/java/org/biouno/unochoice/model/ScriptlerScript.java
+++ b/src/main/java/org/biouno/unochoice/model/ScriptlerScript.java
@@ -38,6 +38,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.bind.JavaScriptMethod;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Extension;
 import hudson.Util;
 import hudson.model.ManagementLink;
@@ -188,8 +189,9 @@ public class ScriptlerScript extends AbstractScript {
             return script;
         }
 
+        @SuppressFBWarnings("NP_NULL_ON_SOME_PATH_FROM_RETURN_VALUE")
         private ManagementLink getScriptler() {
-            return Jenkins.getInstance().getExtensionList(ScriptlerManagement.class).get(0);
+            return Jenkins.getInstanceOrNull().getExtensionList(ScriptlerManagement.class).get(0);
         }
 
         /**

--- a/src/main/java/org/biouno/unochoice/model/ScriptlerScript.java
+++ b/src/main/java/org/biouno/unochoice/model/ScriptlerScript.java
@@ -32,7 +32,6 @@ import java.util.Map;
 import org.biouno.unochoice.util.Utils;
 import org.jenkinsci.plugins.scriptler.ScriptlerManagement;
 import org.jenkinsci.plugins.scriptler.config.Script;
-import org.jenkinsci.plugins.scriptler.config.ScriptlerConfiguration;
 import org.jenkinsci.plugins.scriptler.util.ScriptHelper;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
 import org.kohsuke.stapler.DataBoundConstructor;

--- a/src/main/java/org/biouno/unochoice/model/ScriptlerScript.java
+++ b/src/main/java/org/biouno/unochoice/model/ScriptlerScript.java
@@ -128,6 +128,9 @@ public class ScriptlerScript extends AbstractScript {
      */
     public GroovyScript toGroovyScript() {
         final Script scriptler = ScriptHelper.getScript(getScriptlerScriptId(), true);
+        if (scriptler == null) {
+            throw new RuntimeException("Missing required scriptler!");
+        }
         return new GroovyScript(new SecureGroovyScript(scriptler.script, false, null), null);
     }
 

--- a/src/test/java/org/biouno/unochoice/Security470Test.java
+++ b/src/test/java/org/biouno/unochoice/Security470Test.java
@@ -54,7 +54,7 @@ public class Security470Test {
                     null);
             DynamicReferenceParameter param = new DynamicReferenceParameter("whatever", "description", "some-random-name",
                     script, CascadeChoiceParameter.ELEMENT_TYPE_FORMATTED_HTML, "", true);
-            Assert.assertEquals("<img src=\"fail\"><b>text</b>", param.getChoicesAsStringForUI());
+            Assert.assertEquals("<img src=\"fail\" /><b>text</b>", param.getChoicesAsStringForUI());
         }
 
         { // test HTML does not get sanitized when run outside the sandbox

--- a/src/test/java/org/biouno/unochoice/TestAbstractUnoChoiceParameter.java
+++ b/src/test/java/org/biouno/unochoice/TestAbstractUnoChoiceParameter.java
@@ -33,13 +33,9 @@ import org.jenkinsci.plugins.scriptsecurity.scripts.languages.GroovyLanguage;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
 import org.kohsuke.stapler.StaplerRequest;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
+import org.mockito.Mockito;
 
 import hudson.model.ParameterValue;
 import hudson.model.StringParameterValue;
@@ -48,9 +44,6 @@ import net.sf.json.JSONObject;
 /**
  * Test the behavior of the {@link AbstractUnoChoiceParameter}.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({StaplerRequest.class})
-@PowerMockIgnore({"javax.crypto.*" })
 public class TestAbstractUnoChoiceParameter {
 
     private final String SCRIPT = "return ['a', 'b']";
@@ -79,8 +72,8 @@ public class TestAbstractUnoChoiceParameter {
         json.put("name", "name");
         json.put("value", "value");
 
-        StaplerRequest request = PowerMockito.mock(StaplerRequest.class);
-        PowerMockito.when(request.bindJSON(StringParameterValue.class, json)).thenReturn((StringParameterValue) value);
+        StaplerRequest request = Mockito.mock(StaplerRequest.class);
+        Mockito.when(request.bindJSON(StringParameterValue.class, json)).thenReturn((StringParameterValue) value);
 
         value = param.createValue(request, json);
 

--- a/src/test/java/org/biouno/unochoice/issue51296/TestProjectNameAfterRenaming.java
+++ b/src/test/java/org/biouno/unochoice/issue51296/TestProjectNameAfterRenaming.java
@@ -41,18 +41,8 @@ import org.junit.Test;
 import org.jvnet.hudson.test.Issue;
 import org.jvnet.hudson.test.JenkinsRule;
 
-import org.powermock.api.mockito.PowerMockito;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersDefinitionProperty;
-
-import org.kohsuke.stapler.Ancestor;
-import org.kohsuke.stapler.Stapler;
-import org.kohsuke.stapler.StaplerRequest;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.modules.junit4.PowerMockRunner;
-import org.junit.runner.RunWith;
-import hudson.model.AbstractItem;
 
 /**
  * Tests for projectName being correct after renaming project. See JENKINS-51296.
@@ -60,9 +50,6 @@ import hudson.model.AbstractItem;
  * @since 2.2
  */
 @Issue("JENKINS-51296")
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({StaplerRequest.class, Stapler.class})
-@PowerMockIgnore({"javax.crypto.*" })
 public class TestProjectNameAfterRenaming {
     @Rule
     public JenkinsRule j = new JenkinsRule();
@@ -92,13 +79,6 @@ public class TestProjectNameAfterRenaming {
         GroovyScript listScript = new GroovyScript(new SecureGroovyScript(SCRIPT_LIST, Boolean.FALSE, null),
                                                     new SecureGroovyScript(FALLBACK_SCRIPT_LIST, Boolean.FALSE, null));
         
-        PowerMockito.mockStatic(Stapler.class);
-
-        StaplerRequest request = PowerMockito.mock(StaplerRequest.class);
-        Ancestor ancestor = PowerMockito.mock(Ancestor.class);
-        PowerMockito.when(Stapler.getCurrentRequest()).thenReturn(request);
-        PowerMockito.when(request.findAncestor(AbstractItem.class)).thenReturn(ancestor);
-        PowerMockito.when(ancestor.getObject()).thenReturn(project);
         ChoiceParameter listParam = new ChoiceParameter(PARAMETER_NAME, "description...", "random-name", listScript,
                 CascadeChoiceParameter.PARAMETER_TYPE_SINGLE_SELECT, false, 1);
 

--- a/src/test/java/org/biouno/unochoice/util/TestUtils.java
+++ b/src/test/java/org/biouno/unochoice/util/TestUtils.java
@@ -30,43 +30,21 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Set;
 
-import org.jenkinsci.plugins.scriptler.config.Script;
 import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.jvnet.hudson.test.JenkinsRule;
-import org.powermock.api.mockito.PowerMockito;
-import org.powermock.core.classloader.annotations.PowerMockIgnore;
-import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import hudson.slaves.EnvironmentVariablesNodeProperty;
 
 /**
  * Test the {@link Utils} utility class.
  */
-@RunWith(PowerMockRunner.class)
-@PrepareForTest({ Utils.class })
-@PowerMockIgnore({"javax.crypto.*" })
 public class TestUtils {
 
     @Rule
-    JenkinsRule j = new JenkinsRule();
-
-    @Test
-    public void testGetAllScriptlerScripts() {
-        Set<Script> fakeScripts = new HashSet<Script>();
-        fakeScripts.add(new Script("id", "name", "comment", true, "originCatalog", "originScript", "originDate", true,
-                null, true));
-        PowerMockito.mockStatic(Utils.class);
-        PowerMockito.when(Utils.getAllScriptlerScripts()).thenReturn(fakeScripts);
-        Set<Script> scripts = Utils.getAllScriptlerScripts();
-        assertEquals(1, scripts.size());
-    }
+    public JenkinsRule j = new JenkinsRule();
 
     @Test
     public void testIsSelected() {


### PR DESCRIPTION
Using git-plugin as reference. One major issue is that the build is failing due to hamcrest dependency, coming from powermock.

I think we will need to update to JUnit5, and replace Powermock with... mockito maybe.