### PR TITLE
[JENKINS-61243]: log (fine) if failed to add a parameter definition in Utils class, but don't blow exception; keep working on other params and eval the parameter definition

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,6 +616,7 @@ via [@tupilabs](https://twitter.com/tupilabs)
 2. [JENKINS-61751](https://issues.jenkins-ci.org/browse/JENKINS-61751): let :disabled and :deleted at the same (thanks to @ivarmu)
 3. [JENKINS-62317](https://issues.jenkins-ci.org/browse/JENKINS-62317): Upgrade dependencies pre 2.3 release (Jenkins LTS 2.204 now, Java 8, script-security 1.72, antisamy-markup-formatter 2.0, no more powermockito in tests, fixing spot bugs issues)
 4. [JENKINS-39742](https://issues.jenkins-ci.org/browse/JENKINS-39742): Active Choice Plugin should honor ParameterDefinition serializability (was: Active Choice Plugin in Pipelines throw NotSerializableException)
+5. [JENKINS-61243](https://issues.jenkins-ci.org/browse/JENKINS-61243): Artifactory plugin to fail active-choice plugin
 
 ##### Version 2.2 (2019/09/13)
 

--- a/src/main/java/org/biouno/unochoice/util/Utils.java
+++ b/src/main/java/org/biouno/unochoice/util/Utils.java
@@ -37,6 +37,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javax.annotation.CheckForNull;
 import javax.annotation.Nonnull;
@@ -70,6 +72,8 @@ import org.acegisecurity.Authentication;
  * @since 0.23
  */
 public class Utils {
+
+    protected static final Logger LOGGER = Logger.getLogger(Utils.class.getName());
 
     private Utils() {}
 
@@ -313,10 +317,26 @@ public class Utils {
             try {
                 propertyDescriptors = Introspector.getBeanInfo(buildWrapper.getClass()).getPropertyDescriptors();
             } catch (IntrospectionException e) {
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.log(Level.FINE,
+                            String.format("Introspector.getBeanInfo failed for build wrapper class: [%s]",
+                                    buildWrapper.getClass()
+                                            .getCanonicalName()),
+                            e);
+                }
                 continue;
             }
             for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {
-                addParameterDefinitionsTo(value, buildWrapper, propertyDescriptor);
+                try {
+                    addParameterDefinitionsTo(value, buildWrapper, propertyDescriptor);
+                } catch (RuntimeException e) {
+                    if (LOGGER.isLoggable(Level.FINE)) {
+                        LOGGER.log(Level.FINE,
+                                String.format("Failed to add parameter [%s] to the ParameterDefinition list",
+                                        propertyDescriptor.getName()),
+                                e);
+                    }
+                }
             }
             if (!value.isEmpty()) {
                 result.put(buildWrapper, value);


### PR DESCRIPTION
Using reflection API can lead to issues which should not prevent the plug-in of working. In the worst case, we won't be able to load a parameter definition from some plug-in, but still, we should continue as what we are more likely looking for are parameters compatible with active-choices anyway.

This PR also uses a logger to indicate the error happened under `jul.Level.FINE`, so users can report the error and include the exception stack trace in case the issue causes their jobs to work incorrectly.

Bruno