### PR TITLE
[JENKINS-62215] Create new markup formatter and policy based on 'Safe HTML' that allows input

### DIFF
--- a/src/main/java/org/biouno/unochoice/model/GroovyScript.java
+++ b/src/main/java/org/biouno/unochoice/model/GroovyScript.java
@@ -32,7 +32,7 @@ import java.util.logging.Logger;
 
 import javax.annotation.Nullable;
 
-import hudson.markup.RawHtmlMarkupFormatter;
+import org.biouno.unochoice.util.SafeHtmlExtendedMarkupFormatter;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ApprovalContext;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -121,7 +121,7 @@ public class GroovyScript extends AbstractScript {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see org.biouno.unochoice.model.Script#eval()
      */
     @Override
@@ -131,7 +131,7 @@ public class GroovyScript extends AbstractScript {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see org.biouno.unochoice.model.Script#eval(java.util.Map)
      */
     @Override
@@ -171,7 +171,7 @@ public class GroovyScript extends AbstractScript {
             Object returnValue = secureScript.evaluate(cl, context);
             if (returnValue instanceof CharSequence) {
                 if (secureScript.isSandbox()) {
-                    return new RawHtmlMarkupFormatter(false).translate(returnValue.toString());
+                    return SafeHtmlExtendedMarkupFormatter.INSTANCE.translate(returnValue.toString());
                 }
             }
             return returnValue;
@@ -182,7 +182,7 @@ public class GroovyScript extends AbstractScript {
                     Object returnValue = secureFallbackScript.evaluate(cl, context);
                     if (returnValue instanceof CharSequence) {
                         if (secureFallbackScript.isSandbox()) {
-                            return new RawHtmlMarkupFormatter(false).translate(returnValue.toString());
+                            return SafeHtmlExtendedMarkupFormatter.INSTANCE.translate(returnValue.toString());
                         }
                     }
                     return returnValue;
@@ -199,7 +199,7 @@ public class GroovyScript extends AbstractScript {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see java.lang.Object#toString()
      */
     @Override
@@ -211,7 +211,7 @@ public class GroovyScript extends AbstractScript {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see java.lang.Object#hashCode()
      */
     @Override
@@ -225,7 +225,7 @@ public class GroovyScript extends AbstractScript {
 
     /*
      * (non-Javadoc)
-     * 
+     *
      * @see java.lang.Object#equals(java.lang.Object)
      */
     @Override

--- a/src/main/java/org/biouno/unochoice/util/SafeHtmlExtendedMarkupFormatter.java
+++ b/src/main/java/org/biouno/unochoice/util/SafeHtmlExtendedMarkupFormatter.java
@@ -13,7 +13,7 @@ import java.io.Writer;
 
 public class SafeHtmlExtendedMarkupFormatter extends MarkupFormatter {
 
-    public static SafeHtmlExtendedMarkupFormatter INSTANCE = new SafeHtmlExtendedMarkupFormatter();
+    public static final SafeHtmlExtendedMarkupFormatter INSTANCE = new SafeHtmlExtendedMarkupFormatter();
 
     /**
      * {@link BasicPolicy#POLICY_DEFINITION} is the policy used by {@link hudson.markup.RawHtmlMarkupFormatter}.

--- a/src/main/java/org/biouno/unochoice/util/SafeHtmlExtendedMarkupFormatter.java
+++ b/src/main/java/org/biouno/unochoice/util/SafeHtmlExtendedMarkupFormatter.java
@@ -20,9 +20,11 @@ public class SafeHtmlExtendedMarkupFormatter extends MarkupFormatter {
      * We start from that secure policy and then extend it to include required elements for this plugin.
      */
     private static final PolicyFactory POLICY = BasicPolicy.POLICY_DEFINITION.and(new HtmlPolicyBuilder()
-        .allowElements("input", "textarea")
+        .allowElements("input", "textarea", "select", "option")
         .allowAttributes("id", "type", "name", "value", "placeholder", "disabled", "checked", "max", "maxlength", "min", "minlength", "multiple", "pattern", "readonly", "step").onElements("input")
         .allowAttributes("id", "maxlength", "name", "placeholder", "disabled", "readonly", "wrap", "rows", "cols").onElements("textarea")
+        .allowAttributes("id", "disabled", "multiple", "name", "required", "size").onElements("select")
+        .allowAttributes("id", "disabled", "label", "selected", "value").onElements("option")
         .toFactory());
 
     /**

--- a/src/main/java/org/biouno/unochoice/util/SafeHtmlExtendedMarkupFormatter.java
+++ b/src/main/java/org/biouno/unochoice/util/SafeHtmlExtendedMarkupFormatter.java
@@ -1,0 +1,41 @@
+package org.biouno.unochoice.util;
+
+import com.google.common.base.Throwables;
+import hudson.markup.BasicPolicy;
+import hudson.markup.MarkupFormatter;
+import org.owasp.html.HtmlPolicyBuilder;
+import org.owasp.html.HtmlSanitizer;
+import org.owasp.html.HtmlStreamRenderer;
+import org.owasp.html.PolicyFactory;
+
+import java.io.IOException;
+import java.io.Writer;
+
+public class SafeHtmlExtendedMarkupFormatter extends MarkupFormatter {
+
+    public static SafeHtmlExtendedMarkupFormatter INSTANCE = new SafeHtmlExtendedMarkupFormatter();
+
+    private static final PolicyFactory POLICY = BasicPolicy.POLICY_DEFINITION.and(new HtmlPolicyBuilder()
+        .allowElements("input", "textarea")
+        .allowAttributes("id", "type", "name", "value", "placeholder", "disabled", "checked", "max", "maxlength", "min", "minlength", "multiple", "pattern", "readonly", "step").onElements("input")
+        .allowAttributes("id", "maxlength", "name", "placeholder", "disabled", "readonly", "wrap", "rows", "cols").onElements("textarea")
+        .toFactory());
+
+    /**
+     * Copied from {@link hudson.markup.RawHtmlMarkupFormatter#translate(String, Writer)}
+     */
+    @Override
+    public void translate(String markup, Writer output) throws IOException {
+        HtmlStreamRenderer renderer = HtmlStreamRenderer.create(
+            output,
+            // Receives notifications on a failure to write to the output.
+            Throwables::propagate, // System.out suppresses IOExceptions
+            // Our HTML parser is very lenient, but this receives notifications on
+            // truly bizarre inputs.
+            x -> {
+                throw new Error(x);
+            }
+        );
+        HtmlSanitizer.sanitize(markup, POLICY.apply(renderer));
+    }
+}

--- a/src/main/java/org/biouno/unochoice/util/SafeHtmlExtendedMarkupFormatter.java
+++ b/src/main/java/org/biouno/unochoice/util/SafeHtmlExtendedMarkupFormatter.java
@@ -21,10 +21,10 @@ public class SafeHtmlExtendedMarkupFormatter extends MarkupFormatter {
      */
     private static final PolicyFactory POLICY = BasicPolicy.POLICY_DEFINITION.and(new HtmlPolicyBuilder()
         .allowElements("input", "textarea", "select", "option")
-        .allowAttributes("id", "type", "name", "value", "placeholder", "disabled", "checked", "max", "maxlength", "min", "minlength", "multiple", "pattern", "readonly", "step").onElements("input")
-        .allowAttributes("id", "maxlength", "name", "placeholder", "disabled", "readonly", "wrap", "rows", "cols").onElements("textarea")
-        .allowAttributes("id", "disabled", "multiple", "name", "required", "size").onElements("select")
-        .allowAttributes("id", "disabled", "label", "selected", "value").onElements("option")
+        .allowAttributes("id", "class", "style", "type", "name", "value", "placeholder", "disabled", "checked", "max", "maxlength", "min", "minlength", "multiple", "pattern", "readonly", "step").onElements("input")
+        .allowAttributes("id", "class", "style", "maxlength", "name", "placeholder", "disabled", "readonly", "wrap", "rows", "cols").onElements("textarea")
+        .allowAttributes("id", "class", "style", "disabled", "multiple", "name", "required", "size").onElements("select")
+        .allowAttributes("id", "class", "style", "disabled", "label", "selected", "value").onElements("option")
         .toFactory());
 
     /**

--- a/src/main/java/org/biouno/unochoice/util/SafeHtmlExtendedMarkupFormatter.java
+++ b/src/main/java/org/biouno/unochoice/util/SafeHtmlExtendedMarkupFormatter.java
@@ -15,6 +15,10 @@ public class SafeHtmlExtendedMarkupFormatter extends MarkupFormatter {
 
     public static SafeHtmlExtendedMarkupFormatter INSTANCE = new SafeHtmlExtendedMarkupFormatter();
 
+    /**
+     * {@link BasicPolicy#POLICY_DEFINITION} is the policy used by {@link hudson.markup.RawHtmlMarkupFormatter}.
+     * We start from that secure policy and then extend it to include required elements for this plugin.
+     */
     private static final PolicyFactory POLICY = BasicPolicy.POLICY_DEFINITION.and(new HtmlPolicyBuilder()
         .allowElements("input", "textarea")
         .allowAttributes("id", "type", "name", "value", "placeholder", "disabled", "checked", "max", "maxlength", "min", "minlength", "multiple", "pattern", "readonly", "step").onElements("input")

--- a/src/test/java/org/biouno/unochoice/issue62215/TestMarkupFormatterAllowsRequiredElementsInScriptOutput.java
+++ b/src/test/java/org/biouno/unochoice/issue62215/TestMarkupFormatterAllowsRequiredElementsInScriptOutput.java
@@ -1,0 +1,36 @@
+package org.biouno.unochoice.issue62215;
+
+import org.biouno.unochoice.model.GroovyScript;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import static org.junit.Assert.*;
+
+@Issue("62215")
+public class TestMarkupFormatterAllowsRequiredElementsInScriptOutput {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+
+    @Test
+    public void testInputIsNotRemovedFromGroovySandboxOutput() {
+        String markup = "<input type=\"text\" name=\"value\" value=\"value\" />";
+        GroovyScript script = new GroovyScript(new SecureGroovyScript("return '" + markup + "'", true, null), null);
+        String result = (String) script.eval();
+
+        assertEquals(markup, result);
+    }
+
+    @Test
+    public void testTextareaIsNotRemovedFromGroovySandboxOutput() {
+        String markup = "<textarea name=\"value\" placeholder=\"test\"></textarea>";
+        GroovyScript script = new GroovyScript(new SecureGroovyScript("return '" + markup + "'", true, null), null);
+        String result = (String) script.eval();
+
+        assertEquals(markup, result);
+    }
+}

--- a/src/test/java/org/biouno/unochoice/issue62215/TestMarkupFormatterAllowsRequiredElementsInScriptOutput.java
+++ b/src/test/java/org/biouno/unochoice/issue62215/TestMarkupFormatterAllowsRequiredElementsInScriptOutput.java
@@ -33,4 +33,13 @@ public class TestMarkupFormatterAllowsRequiredElementsInScriptOutput {
 
         assertEquals(markup, result);
     }
+
+    @Test
+    public void testSelectIsNotRemovedFromGroovySandboxOutput() {
+        String markup = "<select id=\"cars\"><option value=\"volvo\">Volvo</option><option value=\"saab\">Saab</option><option value=\"opel\">Opel</option><option value=\"audi\">Audi</option></select>";
+        GroovyScript script = new GroovyScript(new SecureGroovyScript("return '" + markup + "'", true, null), null);
+        String result = (String) script.eval();
+
+        assertEquals(markup, result);
+    }
 }

--- a/src/test/java/org/biouno/unochoice/issue62215/package-info.java
+++ b/src/test/java/org/biouno/unochoice/issue62215/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2019 Ioannis Moutsatsos, Bruno P. Kinoshita
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * Tests for input element with markup sanitation. See JENKINS-62215
+ *
+ * @since 2.4
+ */
+package org.biouno.unochoice.issue62215;


### PR DESCRIPTION
Alternative to https://github.com/jenkinsci/active-choices-plugin/pull/36 and a complete solution for [JENKINS-62215](https://issues.jenkins-ci.org/browse/JENKINS-62215)

This creates a custom `MarkupFormatter` for this plugin only (it won't show up in `Manage Jenkins -> Configure Global Security), based on the policy in https://github.com/jenkinsci/antisamy-markup-formatter-plugin with the following elements added to the allow list: `input`, `textarea`