### PR TITLE
[JENKINS-63963] Use a LinkedHashMap when sanitizing the map (Groovy uses LinkedHashMap by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -693,6 +693,10 @@ via [@tupilabs](https://twitter.com/tupilabs)
 
 ## Release Notes
 
+##### Version 2.5.1 (2020/10/17)
+
+1. [JENKINS-63963](https://issues.jenkins-ci.org/browse/JENKINS-63963): Groovy-backed cascade selects lose sorting/option order after 2.5 upgrade.
+
 ##### Version 2.5 (2020/10/13)
 
 1. [JENKINS-63284](https://issues.jenkins-ci.org/browse/JENKINS-63284): add note to README about pipelines support

--- a/src/main/java/org/biouno/unochoice/model/GroovyScript.java
+++ b/src/main/java/org/biouno/unochoice/model/GroovyScript.java
@@ -26,7 +26,7 @@ package org.biouno.unochoice.model;
 
 import java.io.IOException;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -226,7 +226,7 @@ public class GroovyScript extends AbstractScript {
         } else if (returnValue instanceof Map) {
             @SuppressWarnings("unchecked")
             Map<Object, Object> map = (Map<Object, Object>) returnValue;
-            Map<Object, Object> returnMap = new HashMap<>(map.size());
+            Map<Object, Object> returnMap = new LinkedHashMap<>(map.size());
             map.forEach((key, value) -> {
                 String newKey = sanitizeString(key);
                 String newValue = sanitizeString(value);

--- a/src/test/java/org/biouno/unochoice/issue63963/TestGroovyScriptParametersOrder.java
+++ b/src/test/java/org/biouno/unochoice/issue63963/TestGroovyScriptParametersOrder.java
@@ -1,0 +1,148 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2020 Ioannis Moutsatsos, Bruno P. Kinoshita
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.biouno.unochoice.issue63963;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import org.biouno.unochoice.CascadeChoiceParameter;
+import org.biouno.unochoice.model.GroovyScript;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
+import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.JenkinsRule.WebClient;
+import org.xml.sax.SAXException;
+
+import com.gargoylesoftware.htmlunit.html.DomElement;
+import com.gargoylesoftware.htmlunit.html.DomNode;
+import com.gargoylesoftware.htmlunit.html.HtmlOption;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.gargoylesoftware.htmlunit.html.HtmlSelect;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.ParametersDefinitionProperty;
+import hudson.model.StringParameterDefinition;
+
+/**
+ * Test that verifies that the order of parameters is correct
+ * when using a {@code Map}.
+ *
+ * @since 2.5.1
+ */
+public class TestGroovyScriptParametersOrder {
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    /**
+     * Using test kindly provided by Jason Antman in JENKINS-63963. See issue in JIRA for more context
+     * about the problem, analysis, and solution (mostly done by Jason).
+     *
+     * @throws IOException
+     * @throws SAXException
+     */
+    @Test
+    public void testGroovyScriptParametersOrder() throws IOException, SAXException {
+        FreeStyleProject project = j.createFreeStyleProject();
+
+        StringParameterDefinition teamUid = new StringParameterDefinition("TEAM_UID", "foo", "Team name (UID)");
+        StringParameterDefinition environment = new StringParameterDefinition("ENVIRONMENT", "bar", "The environment name to use for this stack (default: dev)");
+
+        String scriptText = "Map getOptions(String teamId, String enviro) {\n"
+                + "    def found_snapshots = [\"\":\"Select a backup file or snapshot to restore for \" + teamId + \" enviro \" + enviro]; // value => selection text\n"
+                + "    found_snapshots[\"one\"] = \"snapshot e\";\n"
+                + "    found_snapshots[\"two\"] = \"snapshot d\";\n"
+                + "    found_snapshots[\"three\"] = \"snapshot c\";\n"
+                + "    found_snapshots[\"four\"] = \"snapshot b\";\n"
+                + "    found_snapshots[\"five\"] = \"snapshot a\";\n"
+                + "    return found_snapshots;\n"
+                + "}\n"
+                + "\n"
+                + "// get the choice parameters\n"
+                + "if (binding.variables.get(\"TEAM_UID\") == null) { return [''] }\n"
+                + "def team_uid = binding.variables.get(\"TEAM_UID\")\n"
+                + "if (binding.variables.get(\"ENVIRONMENT\") == null) { return [''] }\n"
+                + "def environment = binding.variables.get(\"ENVIRONMENT\")\n"
+                + "if(environment == '' || team_uid == '') { return [''] }\n"
+                + "def snapshots;\n"
+                + "snapshots = getOptions(team_uid, environment);\n"
+                + "return snapshots;";
+        ScriptApproval.get().approveSignature("method groovy.lang.Binding getVariables");
+        SecureGroovyScript secureScript = new SecureGroovyScript(scriptText, true, null);
+
+        GroovyScript script = new GroovyScript(secureScript, secureScript);
+        CascadeChoiceParameter backupFileName = new CascadeChoiceParameter(
+                "BACKUP_FILENAME",
+                "Backup filename parameter",
+                "random-name",
+                script,
+                CascadeChoiceParameter.PARAMETER_TYPE_SINGLE_SELECT,
+                "TEAM_UID,ENVIRONMENT",
+                true,
+                1);
+
+        project.addProperty(new ParametersDefinitionProperty(Arrays.asList(teamUid, environment, backupFileName)));
+        project.save();
+
+
+        WebClient wc = j.createWebClient();
+        wc.setThrowExceptionOnFailingStatusCode(false);
+        HtmlPage configPage = wc.goTo("job/" + project.getName() + "/build?delay=0sec");
+        DomElement renderedParameterElement = configPage.getElementById("random-name");
+        HtmlSelect select = null;
+        for (DomNode node: renderedParameterElement.getChildren()) {
+            if (node instanceof HtmlSelect) {
+                select = (HtmlSelect) node;
+                break;
+            }
+        }
+        if (select == null) {
+            fail("Missing cascade parameter select HTML node element!");
+        }
+        List<HtmlOption> htmlOptions = select.getOptions();
+        final List<String> options = htmlOptions
+                .stream()
+                .map(option -> option.getText())
+                .collect(Collectors.toList());
+        final List<String> expected = new LinkedList<>();
+        {
+            expected.add("Select a backup file or snapshot to restore for foo enviro bar");
+            expected.add("snapshot e");
+            expected.add("snapshot d");
+            expected.add("snapshot c");
+            expected.add("snapshot b");
+            expected.add("snapshot a");
+        }
+        assertEquals("Wrong number of HTML options rendered", expected.size(), options.size());
+        assertEquals("Wrong HTML options rendered (or out of order)", expected, options);
+    }
+}

--- a/src/test/java/org/biouno/unochoice/jenkins_cert_2008/TestGroovyScriptXssVulnerabilities.java
+++ b/src/test/java/org/biouno/unochoice/jenkins_cert_2008/TestGroovyScriptXssVulnerabilities.java
@@ -21,7 +21,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package jenkins_cert_2008;
+package org.biouno.unochoice.jenkins_cert_2008;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;


### PR DESCRIPTION
By default Groovy uses a [LinkedHashMap](http://docs.groovy-lang.org/latest/html/groovy-jdk/java/util/Map.html) (Today-I-Learned!). When we sanitize parameter values that use `Map`'s, we iterate and create a new `HashMap`, causing the elements to be out of order when rendered.