### PR TITLE
WIP: [JENKINS-63284] Add initial Pipeline job support for Groovy properties

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ test-output/
 .project
 **/*~
 *.iml
+.idea/

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>antisamy-markup-formatter</artifactId>
-            <version>2.0</version>
+            <version>2.1</version>
         </dependency>
         <!-- testing -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -103,10 +103,16 @@
             <artifactId>antisamy-markup-formatter</artifactId>
             <version>2.1</version>
         </dependency>
-        <!-- testing -->
+        <!-- Test scope -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-aggregator</artifactId>
+            <version>2.6</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>4.1</version>
+        <version>4.17</version>
         <relativePath />
     </parent>
 

--- a/src/main/java/org/biouno/unochoice/AbstractScriptableParameter.java
+++ b/src/main/java/org/biouno/unochoice/AbstractScriptableParameter.java
@@ -24,13 +24,12 @@
 
 package org.biouno.unochoice;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.logging.Level;
-
+import hudson.model.AbstractItem;
+import hudson.model.Job;
+import hudson.model.ParameterValue;
+import hudson.model.Run;
+import hudson.model.StringParameterValue;
+import jenkins.model.Jenkins;
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
 import org.biouno.unochoice.model.Script;
@@ -40,12 +39,12 @@ import org.kohsuke.stapler.Ancestor;
 import org.kohsuke.stapler.Stapler;
 import org.kohsuke.stapler.StaplerRequest;
 
-import hudson.model.AbstractBuild;
-import hudson.model.AbstractItem;
-import hudson.model.ParameterValue;
-import hudson.model.Project;
-import hudson.model.StringParameterValue;
-import jenkins.model.Jenkins;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.logging.Level;
 
 /**
  * Base class for parameters with scripts.
@@ -134,6 +133,7 @@ public abstract class AbstractScriptableParameter extends AbstractUnoChoiceParam
         String projectName = null;
         String projectFullName = null;
         if (currentRequest != null) {
+            // TODO: Check if we really need AbstractItem instead of Job class
             final Ancestor ancestor = currentRequest.findAncestor(AbstractItem.class);
             if (ancestor != null) {
                 final Object o = ancestor.getObject();
@@ -176,10 +176,10 @@ public abstract class AbstractScriptableParameter extends AbstractUnoChoiceParam
         final Map<Object, Object> helperParameters = new LinkedHashMap<>();
 
         // First, if the project name is set, we then find the project by its name, and inject into the map
-        Project<?, ?> project = null;
+        Job<?, ?> project = null;
         if (StringUtils.isNotBlank(this.projectFullName)) {
             // First try full name if exists
-            project = Jenkins.get().getItemByFullName(this.projectFullName, Project.class);
+            project = Jenkins.get().getItemByFullName(this.projectFullName, Job.class);
         } else if (StringUtils.isNotBlank(this.projectName)) {
             // next we try to get the item given its name, which is more efficient
             project = Utils.getProjectByName(this.projectName);
@@ -191,7 +191,7 @@ public abstract class AbstractScriptableParameter extends AbstractUnoChoiceParam
         }
         if (project != null) {
             helperParameters.put(JENKINS_PROJECT_VARIABLE_NAME, project);
-            AbstractBuild<?, ?> build = project.getLastBuild();
+            Run<?, ?> build = project.getLastBuild();
             if (build != null && build.getHasArtifacts()) {
                 helperParameters.put(JENKINS_BUILD_VARIABLE_NAME, build);
             }

--- a/src/test/java/org/biouno/unochoice/TestJenkinsProjectPropertyValue.java
+++ b/src/test/java/org/biouno/unochoice/TestJenkinsProjectPropertyValue.java
@@ -1,0 +1,93 @@
+package org.biouno.unochoice;
+
+import hudson.model.FreeStyleProject;
+import hudson.model.Job;
+import hudson.model.ParametersDefinitionProperty;
+import org.biouno.unochoice.model.GroovyScript;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
+import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.io.IOException;
+import java.util.Map;
+
+import static org.biouno.unochoice.AbstractScriptableParameter.JENKINS_PROJECT_VARIABLE_NAME;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TestJenkinsProjectPropertyValue {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    private final String PROJECT_NAME = "MyJenkinsJob";
+    private final String PARAMETER_NAME = "MY_PARAMETER_NAME";
+
+    private final int MAX_INDEX = 6;
+    // Popular ways to get property value.
+    private final String SCRIPT_LIST = "try {\n" +
+            "    return ['Test',\n" +
+            "           \"1-${" + JENKINS_PROJECT_VARIABLE_NAME + ".getName()}\",\n" +
+            "           \"2-${binding." + JENKINS_PROJECT_VARIABLE_NAME + ".getName()}\",\n" +
+            "           \"3-${this.binding." + JENKINS_PROJECT_VARIABLE_NAME + ".getName()}\",\n" +
+            "           \"4-${binding.getProperty('" + JENKINS_PROJECT_VARIABLE_NAME + "').getName()}\",\n" +
+            "           \"5-${this.binding.getProperty('" + JENKINS_PROJECT_VARIABLE_NAME + "').getName()}\",\n" +
+            "           \"" + MAX_INDEX + "-${this.getProperty('" + JENKINS_PROJECT_VARIABLE_NAME + "').getName()}\",\n" +
+            "    ]\n" +
+            "}\n" +
+            " catch (e) {\n" +
+            "    return [e.toString(),]\n" +
+            "}\n";
+    private final String FALLBACK_SCRIPT_LIST = "return ['ERROR!',]";
+
+    private final String EXPECTED_VALUE = PROJECT_NAME;
+
+    @Before
+    public void setUp() throws Exception {
+        // .getName() prerequisite
+        ScriptApproval.get().approveSignature("method hudson.model.Item getName");
+        // binding.jenkinsProject/binding.getProperty()/this.getProperty() prerequisite
+        ScriptApproval.get().approveSignature("method groovy.lang.GroovyObject getProperty java.lang.String");
+    }
+
+    @Test
+    public void testFreestyleJob() throws IOException {
+        FreeStyleProject project = j.createProject(FreeStyleProject.class, PROJECT_NAME);
+        testPropertyValueForJob(project);
+    }
+
+    @Test
+    public void testPipelineJob() throws IOException {
+        WorkflowJob project = j.createProject(WorkflowJob.class, PROJECT_NAME);
+        testPropertyValueForJob(project);
+    }
+
+    private void testPropertyValueForJob(Job<?, ?> project) throws IOException {
+        GroovyScript listScript = new GroovyScript(new SecureGroovyScript(SCRIPT_LIST, true, null),
+                new SecureGroovyScript(FALLBACK_SCRIPT_LIST, true, null));
+
+        ChoiceParameter listParam = new ChoiceParameter(PARAMETER_NAME, "description...", "random-name", listScript,
+                CascadeChoiceParameter.PARAMETER_TYPE_SINGLE_SELECT, false, 1);
+
+        ParametersDefinitionProperty paramsDef = new ParametersDefinitionProperty(listParam);
+
+        project.addProperty(paramsDef);
+
+        Map<Object, Object> listSelectionValue = listParam.getChoices();
+        assertFalse("Choices map is empty.", listSelectionValue.isEmpty());
+
+        String choicesStatus = listParam.getChoicesAsString();
+        assertFalse(
+                "Something went wrong. Exception: " + choicesStatus,
+                choicesStatus.contains("Exception")
+        );
+
+        assertTrue("Value 'Test' is not presented in choices: " + choicesStatus + ".", listSelectionValue.containsKey("Test"));
+        for (int i = 1; i < MAX_INDEX; i++) {
+            assertTrue("Wrong project name value with index #" + i + ": " + choicesStatus + ".", listSelectionValue.containsKey(i + "-" + EXPECTED_VALUE));
+        }
+    }
+}


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
**I want** to add support for Pipeline job for Groovy script properties.

**Currently**, the plugin does not fully work with the Pipeline job: it uses classes that are specific only for the Freestyle job for getting extra data to inject to Groovy binding.

**I changed** plugin code to deal with Job/Run classes and added a test that demonstrates the result.

**With these changes**, users will be able to use `jenkinsProject` Groovy property with the Pipeline job.

Related issues: [JENKINS-63284](https://issues.jenkins.io/browse/JENKINS-63284), [JENKINS-65235](https://issues.jenkins.io/browse/JENKINS-65235), [JENKINS-53554](https://issues.jenkins.io/browse/JENKINS-53554).
Related guide: [Writing Pipeline-Compatible Plugins](https://www.jenkins.io/doc/developer/plugin-development/pipeline-integration/#historical-background)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information
-->
