### PR TITLE
Add @DataBoundSetters for deprecated properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,11 @@
             <version>1.9.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.jenkins-ci.plugins.workflow</groupId>
+            <artifactId>workflow-multibranch</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/src/test/java/org/biouno/unochoice/TestPersistingParameters.java
+++ b/src/test/java/org/biouno/unochoice/TestPersistingParameters.java
@@ -27,7 +27,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.net.URL;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -46,6 +50,9 @@ import org.jenkinsci.plugins.scriptler.config.Parameter;
 import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
 import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
 import org.jenkinsci.plugins.scriptsecurity.scripts.languages.GroovyLanguage;
+import org.jenkinsci.plugins.workflow.cps.CpsFlowDefinition;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -211,6 +218,56 @@ public class TestPersistingParameters {
                             String scriptText = ((GroovyScript) leScript).getScript().getScript();
                             String fallbackScriptText = ((GroovyScript) choiceParam.getScript()).getFallbackScript()
                                     .getScript();
+                            assertTrue("Found an empty script!", StringUtils.isNotBlank(scriptText));
+                            assertTrue("Found an empty fallback script!", StringUtils.isNotBlank(fallbackScriptText));
+                            assertEquals(SCRIPT_PARAM002, scriptText);
+                            assertEquals(SCRIPT_FALLBACK_PARAM002, fallbackScriptText);
+                        } else {
+                            String scriptText = FileUtils.readFileToString(scriptFile, Charset.defaultCharset());
+                            assertTrue("Found an empty script!", StringUtils.isNotBlank(scriptText));
+                            assertEquals(SCRIPT_PARAM001, scriptText);
+                            assertEquals("Wrong number of parameters for scriptler parameter!", 1, ((ScriptlerScript) leScript).getParameters().size());
+                            assertEquals("Wrong scriptler parameter name!", "arg1", ((ScriptlerScript) leScript).getParameters()
+                                    .keySet().iterator().next());
+                        }
+                    }
+                }
+            }
+        }
+        // We have two parameters before saving. We must have two now.
+        assertEquals("Didn't find all parameters after persisting xml", 2, found);
+    }
+
+    @Test
+    public void testSaveScriptlerParametersFromPipeline() throws Exception {
+        WorkflowJob job = j.createProject(WorkflowJob.class);
+
+        URL pipelinePath = TestPersistingParameters.class.getResource("PipelineWithScriptlerParameters.groovy");
+        assert pipelinePath != null;
+        byte[] contentBytes = Files.readAllBytes(Paths.get(pipelinePath.toURI()));
+        String pipeline = new String(contentBytes, StandardCharsets.UTF_8);
+        job.setDefinition(new CpsFlowDefinition(pipeline, true));
+
+        QueueTaskFuture<WorkflowRun> future = job.scheduleBuild2(0);
+        assert future != null;
+        WorkflowRun run = future.get();
+        assertEquals(Result.SUCCESS, run.getResult());
+
+        XmlFile configXml = job.getConfigFile();
+        WorkflowJob reReadJob = (WorkflowJob) configXml.read();
+        int found = 0;
+        for (JobProperty<? super WorkflowJob> jobProperty : reReadJob.getProperties().values()) {
+            if (jobProperty instanceof ParametersDefinitionProperty) {
+                ParametersDefinitionProperty paramDef = (ParametersDefinitionProperty) jobProperty;
+                List<ParameterDefinition> parameters = paramDef.getParameterDefinitions();
+                for (ParameterDefinition parameter : parameters) {
+                    if (parameter instanceof AbstractScriptableParameter) {
+                        found++;
+                        AbstractScriptableParameter choiceParam = (AbstractScriptableParameter) parameter;
+                        Script leScript = choiceParam.getScript();
+                        if (leScript instanceof GroovyScript) {
+                            String scriptText = ((GroovyScript) leScript).getScript().getScript();
+                            String fallbackScriptText = ((GroovyScript) leScript).getFallbackScript().getScript();
                             assertTrue("Found an empty script!", StringUtils.isNotBlank(scriptText));
                             assertTrue("Found an empty fallback script!", StringUtils.isNotBlank(fallbackScriptText));
                             assertEquals(SCRIPT_PARAM002, scriptText);

--- a/src/test/resources/org/biouno/unochoice/PipelineWithScriptlerParameters.groovy
+++ b/src/test/resources/org/biouno/unochoice/PipelineWithScriptlerParameters.groovy
@@ -1,0 +1,43 @@
+properties([
+    parameters([
+        [
+            $class: 'ChoiceParameter',
+            choiceType: 'PT_SINGLE_SELECT',
+            description: 'param001 description',
+            filterLength: 1,
+            filterable: true,
+            name: 'param001',
+            randomName: 'random-name',
+            script: [
+                $class: 'ScriptlerScript',
+                scriptlerScriptId: 'dummy.groovy',
+                parameters: [
+                    [name: 'arg1', value: 'bla']
+                ]
+            ]
+        ],
+        [
+            $class: 'CascadeChoiceParameter',
+            choiceType: 'PT_SINGLE_SELECT',
+            description: 'param002 description',
+            filterLength: 1,
+            filterable: true,
+            name: 'param002',
+            randomName: 'random-name',
+            referencedParameters: 'param001',
+            script: [
+                $class: 'GroovyScript',
+                script: [
+                    $class: 'SecureGroovyScript',
+                    script: 'return [PARAM001]',
+                    sandbox: false
+                ],
+                fallbackScript: [
+                    $class: 'SecureGroovyScript',
+                    script: 'return []',
+                    sandbox: false
+                ]
+            ]
+        ]
+    ])
+])


### PR DESCRIPTION
Add @DataBoundSetters for deprecated properties

As ScriptlerScript previously had a @DataBoundConstructor to help
initialize it with a Scriptler script ID and parameters from a pipeline,
removing those from the constructor gave us no backwards-compatible path
to set these properties. This results in an uninitialized Scriptler
script that we'll call to populate the choices.

Add new @DataBoundSetter methods for accepting these legacy fields and
therefore establish backwards compatibility with versions of Active
Choices prior to 2.6.0. Also add unit tests to ensure that this code
works as expected and will continue to work in the future.

Fixes JENKINS-67934.

<!-- Please describe your pull request here. -->

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
