### PR TITLE
[JENKINS-68013] fix referencing boolean parameters

### DIFF
--- a/src/main/resources/org/biouno/unochoice/CascadeChoiceParameter/index.jelly
+++ b/src/main/resources/org/biouno/unochoice/CascadeChoiceParameter/index.jelly
@@ -53,7 +53,7 @@
                         if (child.getAttribute('name') == 'value') {
                             parameterElement = child;
                             break;
-                        } else if (child.tagName == 'DIV') {
+                        } else if (child.tagName == 'DIV' || child.tagName == 'SPAN') {
                             var subValues = jQuery(child).find('input[name="value"]');
                             if (subValues &amp;&amp; subValues.get(0)) {
                                 parameterElement = child;


### PR DESCRIPTION
since newer jenkins-updates, referenced booelan params stopped working
Fix was posted by Jeremy Cooper in Jira: https://issues.jenkins.io/browse/JENKINS-68013?jql=resolution%20is%20EMPTY%20and%20component%3D20520

I added a second selector to look not only for divs, but also spans in referenced parameters

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md  in your own repository 
-->
