### PR TITLE
Use HTTPS SCM URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
     </properties>
 
     <scm>
-        <connection>scm:git:git://github.com/jenkinsci/active-choices-plugin.git</connection>
+        <connection>scm:git:https://github.com/jenkinsci/active-choices-plugin.git</connection>
         <developerConnection>scm:git:git@github.com:jenkinsci/active-choices-plugin.git</developerConnection>
         <url>https://github.com/jenkinsci/active-choices-plugin</url>
         <tag>HEAD</tag>


### PR DESCRIPTION
The old protocol is [deprecated](https://github.blog/2021-09-01-improving-git-protocol-security-github/).