### PR TITLE
Upgrade jQuery from 1.x to 3.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <revision>2.6.6</revision>
         <changelist>-SNAPSHOT</changelist>
-        <jenkins.version>2.332.3</jenkins.version>
+        <jenkins.version>2.332.4</jenkins.version>
         <gitHubRepo>jenkinsci/active-choices-plugin</gitHubRepo>
     </properties>
 
@@ -64,7 +64,7 @@
             <dependency>
                 <groupId>io.jenkins.tools.bom</groupId>
                 <artifactId>bom-2.332.x</artifactId>
-                <version>1409.v7659b_c072f18</version>
+                <version>1763.v092b_8980a_f5e</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -81,15 +81,8 @@
         </dependency>
         <!-- JQuery is included only once -->
         <dependency>
-            <groupId>org.kohsuke.stapler</groupId>
-            <artifactId>stapler-adjunct-jquery</artifactId> <!-- TODO why is this not using org.jenkins-ci.plugins:jquery instead?! -->
-            <version>1.12.4-0</version>
-            <exclusions>
-                <exclusion> <!-- TODO INFRA-1310 pending 1.12.4-0 -->
-                    <groupId>org.kohsuke.stapler</groupId>
-                    <artifactId>stapler</artifactId>
-                </exclusion>
-            </exclusions>
+            <groupId>io.jenkins.plugins</groupId>
+            <artifactId>jquery3-api</artifactId>
         </dependency>
         <!-- script-security plug-in integration -->
         <dependency>
@@ -100,7 +93,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>antisamy-markup-formatter</artifactId>
-            <version>2.7</version>
         </dependency>
         <!-- testing -->
         <dependency>
@@ -111,7 +103,6 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins</groupId>
             <artifactId>matrix-auth</artifactId>
-            <version>3.1.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/main/resources/org/biouno/unochoice/DynamicReferenceParameter/index.jelly
+++ b/src/main/resources/org/biouno/unochoice/DynamicReferenceParameter/index.jelly
@@ -1,7 +1,7 @@
 <?jelly escape-by-default='true' ?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
   ${it.parameters.clear()}
-  <st:adjunct includes="org.kohsuke.stapler.jquery"/>
+  <st:adjunct includes="io.jenkins.plugins.jquery3"/>
   <st:adjunct includes="org.biouno.unochoice.stapler.unochoice"/>
   <j:set var="choiceType" value="${it.choiceType}"/>
   <j:set var="omitValueField" value="${it.omitValueField}"/>

--- a/src/main/resources/org/biouno/unochoice/common/choiceParameterCommon.jelly
+++ b/src/main/resources/org/biouno/unochoice/common/choiceParameterCommon.jelly
@@ -1,6 +1,6 @@
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
-  <st:adjunct includes="org.kohsuke.stapler.jquery"/>
+  <st:adjunct includes="io.jenkins.plugins.jquery3"/>
   <st:adjunct includes="org.biouno.unochoice.stapler.unochoice"/>
   <j:set var="paramName" value="${h.escape(it.randomName)}" scope="parent" />
   <j:set var="choiceType" value="${it.choiceType}"/>


### PR DESCRIPTION
Upgrades jQuery from 1.x to 3.x by depending on the `jquery3-api` plugin. This is the last plugin that depends on `stapler-adjunct-jquery` 1.x, which we would like to deprecate.

I have not tested this change, and I do not use this plugin (nor could I figure out how to use it in five minutes), so please test this change interactively in the GUI before merging and releasing it.