### PR TITLE
test: Add end-to-end tests for UI behavior

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
     <description>This plug-in provides additional parameter types for jobs, that allow you to cascade changes and render images or other HTML elements instead of the traditional parameter.</description>
 
     <url>https://github.com/jenkinsci/active-choices-plugin</url>
-    
+
     <licenses>
         <license>
             <name>The MIT license</name>
@@ -142,6 +142,19 @@
         <dependency>
             <groupId>org.jenkins-ci.plugins.workflow</groupId>
             <artifactId>workflow-basic-steps</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.seleniumhq.selenium</groupId>
+            <artifactId>selenium-java</artifactId>
+            <version>4.10.0</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.github.bonigarcia</groupId>
+            <artifactId>webdrivermanager</artifactId>
+            <version>5.3.3</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/org/biouno/unochoice/UiAcceptanceTest.java
+++ b/src/test/java/org/biouno/unochoice/UiAcceptanceTest.java
@@ -1,0 +1,220 @@
+package org.biouno.unochoice;
+
+import hudson.model.FreeStyleProject;
+import io.github.bonigarcia.wdm.WebDriverManager;
+import org.apache.commons.lang3.StringUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.openqa.selenium.By;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.chrome.ChromeDriver;
+import org.openqa.selenium.chrome.ChromeOptions;
+import org.openqa.selenium.support.ui.Select;
+
+import javax.xml.transform.Source;
+import javax.xml.transform.stream.StreamSource;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class UiAcceptanceTest {
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
+
+    private WebDriver driver;
+
+    @BeforeClass
+    public static void setUpClass() {
+        if (isCi()) {
+            // The browserVersion needs to match what is provided by the Jenkins Infrastructure
+            // If you see an exception like this:
+            //
+            // org.openqa.selenium.SessionNotCreatedException: Could not start a new session. Response code 500. Message: session not created: This version of ChromeDriver only supports Chrome version 114
+            // Current browser version is 112.0.5615.49 with binary path /usr/bin/chromium-browser
+            //
+            // Then that means you need to update the version here to match the current browser version.
+            WebDriverManager.chromedriver().browserVersion("112").setup();
+        } else {
+            WebDriverManager.chromedriver().setup();
+        }
+    }
+
+    private static boolean isCi() {
+        return StringUtils.isNotBlank(System.getenv("CI"));
+    }
+
+    @Before
+    public void setUp() throws Exception {
+        FreeStyleProject freeStyleProject = j.createFreeStyleProject("test");
+        freeStyleProject.updateByXml((Source) new StreamSource(getClass().getClassLoader().getResourceAsStream("test-config.xml")));
+        if (isCi()) {
+            driver = new ChromeDriver(new ChromeOptions().addArguments("--headless", "--disable-dev-shm-usage", "--no-sandbox"));
+        } else {
+            driver = new ChromeDriver(new ChromeOptions());
+        }
+    }
+
+    @After
+    public void tearDown() {
+         driver.quit();
+    }
+
+    @Test
+    public void test() throws Exception {
+        // Load the page
+        driver.get(j.getURL().toString() + "job/test/build");
+
+        /*
+         PARAM1 and PARAM1A are SINGLE_SELECT based
+         */
+        WebElement param1 = driver.findElement(By.cssSelector("div.active-choice:has([name='name'][value='PARAM1']) > select"));
+        WebElement param1A = driver.findElement(By.cssSelector("div.active-choice:has([name='name'][value='PARAM1A']) > select"));
+
+        assertTrue(param1.isDisplayed());
+        assertTrue(param1.isEnabled());
+        assertTrue(param1A.isDisplayed());
+        assertTrue(param1A.isEnabled());
+
+        checkOptions(param1, "A", "B", "C");
+
+        assertEquals("A", new Select(param1).getFirstSelectedOption().getText());
+        param1.sendKeys("A");
+
+        checkOptions(param1A, "A1", "A2", "A3");
+
+        new Select(param1).selectByValue("B");
+        checkOptions(param1A, "B1", "B2", "B3");
+
+        new Select(param1).selectByValue("C");
+        checkOptions(param1A, "C1", "C2", "C3");
+
+        new Select(param1).selectByValue("A");
+        checkOptions(param1A, "A1", "A2", "A3");
+
+        /*
+         PARAM2 and PARAM2A are RADIO based
+         */
+        List<WebElement> param2Choices = driver.findElements(By.cssSelector("div.active-choice:has([name='name'][value='PARAM2']) input[type='radio']"));
+        List<WebElement> param2AChoices = driver.findElements(By.cssSelector("div.active-choice:has([name='name'][value='PARAM2A']) input[type='radio']"));
+
+        checkRadios(param2Choices, "A", "B", "C");
+        // this is until something is selected
+        checkRadios(param2AChoices, "1", "2", "3");
+
+        param2Choices.get(0).click();
+        param2AChoices = driver.findElements(By.cssSelector("div.active-choice:has([name='name'][value='PARAM2A']) input[type='radio']"));
+        checkRadios(param2AChoices, "A1", "A2", "A3");
+
+        param2Choices.get(1).click();
+        param2AChoices = driver.findElements(By.cssSelector("div.active-choice:has([name='name'][value='PARAM2A']) input[type='radio']"));
+        checkRadios(param2AChoices, "B1", "B2", "B3");
+
+        param2Choices.get(2).click();
+        param2AChoices = driver.findElements(By.cssSelector("div.active-choice:has([name='name'][value='PARAM2A']) input[type='radio']"));
+        checkRadios(param2AChoices, "C1", "C2", "C3");
+
+        param2Choices.get(0).click();
+        param2AChoices = driver.findElements(By.cssSelector("div.active-choice:has([name='name'][value='PARAM2A']) input[type='radio']"));
+        checkRadios(param2AChoices, "A1", "A2", "A3");
+
+        /*
+         PARAM3 and PARAM3A are CHECKBOX based
+         */
+        List<WebElement> param3Choices = driver.findElements(By.cssSelector("div.active-choice:has([name='name'][value='PARAM3']) input[type='checkbox']"));
+        List<WebElement> param3AChoices = driver.findElements(By.cssSelector("div.active-choice:has([name='name'][value='PARAM3A']) input[type='checkbox']"));
+
+        checkRadios(param3Choices, "A", "B", "C");
+        // this is until something is selected
+        checkRadios(param3AChoices);
+
+        param3Choices.get(0).click();
+        param3AChoices = driver.findElements(By.cssSelector("div.active-choice:has([name='name'][value='PARAM3A']) input[type='checkbox']"));
+        checkRadios(param3AChoices, "A1", "A2", "A3");
+
+        param3Choices.get(1).click();
+        param3AChoices = driver.findElements(By.cssSelector("div.active-choice:has([name='name'][value='PARAM3A']) input[type='checkbox']"));
+        checkRadios(param3AChoices, "A1", "B1", "A2", "B2", "A3", "B3");
+
+        param3Choices.get(2).click();
+        param3AChoices = driver.findElements(By.cssSelector("div.active-choice:has([name='name'][value='PARAM3A']) input[type='checkbox']"));
+        checkRadios(param3AChoices, "A1", "B1", "C1", "A2", "B2", "C2", "A3", "B3", "C3");
+
+        param3Choices.get(0).click();
+        param3AChoices = driver.findElements(By.cssSelector("div.active-choice:has([name='name'][value='PARAM3A']) input[type='checkbox']"));
+        checkRadios(param3AChoices, "B1", "C1", "B2", "C2", "B3", "C3");
+
+        param3Choices.get(1).click();
+        param3AChoices = driver.findElements(By.cssSelector("div.active-choice:has([name='name'][value='PARAM3A']) input[type='checkbox']"));
+        checkRadios(param3AChoices, "C1", "C2", "C3");
+
+        param3Choices.get(0).click();
+        param3AChoices = driver.findElements(By.cssSelector("div.active-choice:has([name='name'][value='PARAM3A']) input[type='checkbox']"));
+        checkRadios(param3AChoices, "A1", "C1", "A2", "C2", "A3", "C3");
+
+        param3Choices.get(2).click();
+        param3AChoices = driver.findElements(By.cssSelector("div.active-choice:has([name='name'][value='PARAM3A']) input[type='checkbox']"));
+        checkRadios(param3AChoices, "A1", "A2", "A3");
+
+        param3Choices.get(0).click();
+        param3AChoices = driver.findElements(By.cssSelector("div.active-choice:has([name='name'][value='PARAM3A']) input[type='checkbox']"));
+        checkRadios(param3AChoices);
+
+        /*
+         PARAM4 and PARAM4A are MULTI_SELECT based
+         */
+        WebElement param4Input = driver.findElement(By.cssSelector("div.active-choice:has([name='name'][value='PARAM4']) select"));
+        WebElement param4AInput = driver.findElement(By.cssSelector("div.active-choice:has([name='name'][value='PARAM4A']) select"));
+
+        checkOptions(param4Input, "A", "B", "C");
+        // this is until something is selected
+        checkOptions(param4AInput);
+
+        new Select(param4Input).selectByVisibleText("A");
+        checkOptions(param4AInput, "A1", "A2", "A3");
+
+        new Select(param4Input).selectByVisibleText("B");
+        checkOptions(param4AInput, "A1", "B1", "A2", "B2", "A3", "B3");
+
+        new Select(param4Input).selectByVisibleText("C");
+        checkOptions(param4AInput, "A1", "B1", "C1", "A2", "B2", "C2", "A3", "B3", "C3");
+
+        new Select(param4Input).deselectByVisibleText("A");
+        checkOptions(param4AInput, "B1", "C1", "B2", "C2", "B3", "C3");
+
+        new Select(param4Input).deselectByVisibleText("B");
+        checkOptions(param4AInput, "C1", "C2", "C3");
+
+        new Select(param4Input).selectByValue("A");
+        checkOptions(param4AInput, "A1", "C1", "A2", "C2", "A3", "C3");
+
+        new Select(param4Input).deselectByValue("C");
+        checkOptions(param4AInput, "A1", "A2", "A3");
+
+        new Select(param4Input).deselectByValue("A");
+        checkOptions(param4AInput);
+
+    }
+
+    private static void checkOptions(WebElement param1Input, String... options) {
+        assertEquals(options.length, param1Input.findElements(By.cssSelector("option")).size());
+        for (int i = 0; i < options.length; i++) {
+            assertEquals(options[i], param1Input.findElements(By.cssSelector("option")).get(i).getAttribute("value"));
+            assertEquals(options[i], param1Input.findElements(By.cssSelector("option")).get(i).getText());
+        }
+    }
+
+    private static void checkRadios(List<WebElement> radios, String... options) {
+        assertEquals(options.length, radios.size());
+        for (int i = 0; i < options.length; i++) {
+            assertTrue(radios.get(i).isDisplayed());
+            assertTrue(radios.get(i).isEnabled());
+            assertEquals(options[i], radios.get(i).getAttribute("value"));
+        }
+    }
+}

--- a/src/test/resources/test-config.xml
+++ b/src/test/resources/test-config.xml
@@ -1,0 +1,141 @@
+<?xml version="1.0" encoding="UTF-8"?><project>
+    <actions/>
+    <description/>
+    <keepDependencies>false</keepDependencies>
+    <properties>
+        <hudson.model.ParametersDefinitionProperty>
+            <parameterDefinitions>
+                <org.biouno.unochoice.ChoiceParameter>
+                    <name>PARAM1</name>
+                    <description/>
+                    <randomName>choice-parameter-128553354589541</randomName>
+                    <visibleItemCount>1</visibleItemCount>
+                    <script class="org.biouno.unochoice.model.GroovyScript">
+                        <script>
+          return ["A", "B", "C"]
+        </script>
+                        <fallbackScript/>
+                    </script>
+                    <filterable>false</filterable>
+                    <choiceType>PT_SINGLE_SELECT</choiceType>
+                </org.biouno.unochoice.ChoiceParameter>
+                <org.biouno.unochoice.CascadeChoiceParameter>
+                    <name>PARAM1A</name>
+                    <description/>
+                    <randomName>choice-parameter-128553355257416</randomName>
+                    <visibleItemCount>1</visibleItemCount>
+                    <script class="org.biouno.unochoice.model.GroovyScript">
+                        <script>
+          return ["1", "2", "3"].collect {"${PARAM1}${it}".toString()}.toList()
+        </script>
+                        <fallbackScript/>
+                    </script>
+                    <filterable>false</filterable>
+                    <choiceType>PT_SINGLE_SELECT</choiceType>
+                    <referencedParameters>PARAM1</referencedParameters>
+                    <parameters class="linked-hash-map"/>
+                </org.biouno.unochoice.CascadeChoiceParameter>
+                <org.biouno.unochoice.ChoiceParameter>
+                    <name>PARAM2</name>
+                    <description/>
+                    <randomName>choice-parameter-128553356051041</randomName>
+                    <visibleItemCount>1</visibleItemCount>
+                    <script class="org.biouno.unochoice.model.GroovyScript">
+                        <script>
+          return ["A", "B", "C"]
+        </script>
+                        <fallbackScript/>
+                    </script>
+                    <filterable>false</filterable>
+                    <choiceType>PT_RADIO</choiceType>
+                </org.biouno.unochoice.ChoiceParameter>
+                <org.biouno.unochoice.CascadeChoiceParameter>
+                    <name>PARAM2A</name>
+                    <description/>
+                    <randomName>choice-parameter-128553356692125</randomName>
+                    <visibleItemCount>1</visibleItemCount>
+                    <script class="org.biouno.unochoice.model.GroovyScript">
+                        <script>
+          return ["1", "2", "3"].collect {"${PARAM2}${it}".toString()}.toList()
+        </script>
+                        <fallbackScript/>
+                    </script>
+                    <filterable>false</filterable>
+                    <choiceType>PT_RADIO</choiceType>
+                    <referencedParameters>PARAM2</referencedParameters>
+                    <parameters class="linked-hash-map"/>
+                </org.biouno.unochoice.CascadeChoiceParameter>
+                <org.biouno.unochoice.ChoiceParameter>
+                    <name>PARAM3</name>
+                    <description/>
+                    <randomName>choice-parameter-128553357303166</randomName>
+                    <visibleItemCount>1</visibleItemCount>
+                    <script class="org.biouno.unochoice.model.GroovyScript">
+                        <script>
+          return ["A", "B", "C"]
+        </script>
+                        <fallbackScript/>
+                    </script>
+                    <filterable>false</filterable>
+                    <choiceType>PT_CHECKBOX</choiceType>
+                </org.biouno.unochoice.ChoiceParameter>
+                <org.biouno.unochoice.CascadeChoiceParameter>
+                    <name>PARAM3A</name>
+                    <description/>
+                    <randomName>choice-parameter-128553357886666</randomName>
+                    <visibleItemCount>1</visibleItemCount>
+                    <script class="org.biouno.unochoice.model.GroovyScript">
+                        <script>
+          return ["1", "2", "3"].collectMany { inner -&gt; PARAM3.split(",").findAll {it}.collect {"${it}${inner}".toString()}}.toList()
+        </script>
+                        <fallbackScript/>
+                    </script>
+                    <filterable>false</filterable>
+                    <choiceType>PT_CHECKBOX</choiceType>
+                    <referencedParameters>PARAM3</referencedParameters>
+                    <parameters class="linked-hash-map"/>
+                </org.biouno.unochoice.CascadeChoiceParameter>
+                <org.biouno.unochoice.ChoiceParameter>
+                    <name>PARAM4</name>
+                    <description/>
+                    <randomName>choice-parameter-128553358826291</randomName>
+                    <visibleItemCount>1</visibleItemCount>
+                    <script class="org.biouno.unochoice.model.GroovyScript">
+                        <script>
+          return ["A", "B", "C"]
+        </script>
+                        <fallbackScript/>
+                    </script>
+                    <filterable>false</filterable>
+                    <choiceType>PT_MULTI_SELECT</choiceType>
+                </org.biouno.unochoice.ChoiceParameter>
+                <org.biouno.unochoice.CascadeChoiceParameter>
+                    <name>PARAM4A</name>
+                    <description/>
+                    <randomName>choice-parameter-128553359720750</randomName>
+                    <visibleItemCount>1</visibleItemCount>
+                    <script class="org.biouno.unochoice.model.GroovyScript">
+                        <script>
+          return ["1", "2", "3"].collectMany { inner -&gt; PARAM4.split(",").findAll {it}.collect {"${it}${inner}".toString()}}.toList()
+        </script>
+                        <fallbackScript/>
+                    </script>
+                    <filterable>false</filterable>
+                    <choiceType>PT_MULTI_SELECT</choiceType>
+                    <referencedParameters>PARAM4</referencedParameters>
+                    <parameters class="linked-hash-map"/>
+                </org.biouno.unochoice.CascadeChoiceParameter>
+            </parameterDefinitions>
+        </hudson.model.ParametersDefinitionProperty>
+    </properties>
+    <scm class="hudson.scm.NullSCM"/>
+    <canRoam>true</canRoam>
+    <disabled>false</disabled>
+    <blockBuildWhenDownstreamBuilding>false</blockBuildWhenDownstreamBuilding>
+    <blockBuildWhenUpstreamBuilding>false</blockBuildWhenUpstreamBuilding>
+    <triggers/>
+    <concurrentBuild>false</concurrentBuild>
+    <builders/>
+    <publishers/>
+    <buildWrappers/>
+</project>


### PR DESCRIPTION
I want to remove the dependency on Prototype so this plugin is compatible with Jenkins 2.401 and above. Before I do that, I want to write an end-to-end test.

See [this post](https://www.jenkins.io/blog/2023/05/12/removing-prototype-from-jenkins/) for more details on the removal of Prototype.

https://issues.jenkins.io/browse/JENKINS-71365 is the issue for this plugin.
https://github.com/jenkinsci/stapler/pull/452/files shows changes that have been made to stapler which is a dependency of core.

<!-- Please describe your pull request here. -->

### Testing done

This is a pure test PR. It adds a dependency on `org.seleniumhq.selenium:selenium-java` and relies on `ChromeDriver` to run the actual test. The test works in both headless and normal mode.

The test checks for all 4 kinds of params - `SINGLE_SELECT`, `RADIO`, `CHECKBOX`, `MULTI_SELECT`.
It creates `ChoiceParameter` and a `CascadeChoiceParameter` for each kind to check the UI works.

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
