### PR TITLE
Remove outdated Jenkins version test conditional

### DIFF
--- a/src/test/java/org/biouno/unochoice/jenkins_cert_1954/TestParametersXssVulnerabilities.java
+++ b/src/test/java/org/biouno/unochoice/jenkins_cert_1954/TestParametersXssVulnerabilities.java
@@ -52,7 +52,6 @@ import static org.junit.Assert.assertNotNull;
  */
 public class TestParametersXssVulnerabilities {
 
-    private static final VersionNumber TRANSITION_TO_DIV_VERSION = new VersionNumber("2.264");
     @Rule
     public JenkinsRule j = new JenkinsRule();
 
@@ -84,9 +83,7 @@ public class TestParametersXssVulnerabilities {
         try (WebClient wc = j.createWebClient()) {
             wc.setThrowExceptionOnFailingStatusCode(false);
             HtmlPage configPage = wc.goTo("job/" + project.getName() + "/build?delay=0sec");
-            DomNodeList<DomElement> nodes =
-                    Objects.requireNonNull(Jenkins.getStoredVersion()).isNewerThanOrEqualTo(TRANSITION_TO_DIV_VERSION) ?
-                            configPage.getElementsByTagName("div") : configPage.getElementsByTagName("td");
+            DomNodeList<DomElement> nodes = configPage.getElementsByTagName("div");
             DomElement renderedParameterElement = null;
             for (DomElement elem : nodes) {
                 if (elem.getAttribute("class").contains("setting-main")) {


### PR DESCRIPTION
## Remove outdated Jenkins version conditional from test

No longer need to check that Jenkins is newer than 2.264 in the test, since Jenkins 2.375.3 or newer is rquired from the pom file.

### Testing done

Tests pass on Linux with Java 11.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
