### PR TITLE
fix: When configured using a pipeline, handle null filterable

### DIFF
--- a/src/main/java/org/biouno/unochoice/CascadeChoiceParameter.java
+++ b/src/main/java/org/biouno/unochoice/CascadeChoiceParameter.java
@@ -30,6 +30,8 @@ import org.apache.commons.lang.StringUtils;
 import org.biouno.unochoice.model.Script;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.util.Objects;
+
 /**
  * <p>A choice parameter, that gets updated when another parameter changes. The simplest
  * use case for this, would be having a list of states, and when the user selected a
@@ -139,8 +141,8 @@ public class CascadeChoiceParameter extends AbstractCascadableParameter {
      * Get the filter flag.
      * @return filter flag
      */
-    public Boolean getFilterable() {
-        return filterable;
+    public boolean getFilterable() {
+        return Objects.equals(filterable, Boolean.TRUE);
     }
 
     /**

--- a/src/main/java/org/biouno/unochoice/ChoiceParameter.java
+++ b/src/main/java/org/biouno/unochoice/ChoiceParameter.java
@@ -30,6 +30,8 @@ import org.apache.commons.lang.StringUtils;
 import org.biouno.unochoice.model.Script;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.util.Objects;
+
 /**
  * A parameter that renders its options as a choice (select) HTML component.
  *
@@ -126,8 +128,8 @@ public class ChoiceParameter extends AbstractScriptableParameter {
      * Get the filter flag.
      * @return filter flag
      */
-    public Boolean getFilterable() {
-        return filterable;
+    public boolean getFilterable() {
+        return Objects.equals(filterable, Boolean.TRUE);
     }
 
     /**

--- a/src/main/java/org/biouno/unochoice/DynamicReferenceParameter.java
+++ b/src/main/java/org/biouno/unochoice/DynamicReferenceParameter.java
@@ -25,6 +25,7 @@
 package org.biouno.unochoice;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
@@ -118,8 +119,8 @@ public class DynamicReferenceParameter extends AbstractCascadableParameter {
         return this.choiceType;
     }
 
-    public Boolean getOmitValueField() {
-        return omitValueField;
+    public boolean getOmitValueField() {
+        return Objects.equals(omitValueField, Boolean.TRUE);
     }
 
     @JavaScriptMethod

--- a/src/test/java/org/biouno/unochoice/TestCascadeChoiceParameter.java
+++ b/src/test/java/org/biouno/unochoice/TestCascadeChoiceParameter.java
@@ -25,6 +25,7 @@
 package org.biouno.unochoice;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Arrays;
@@ -101,6 +102,23 @@ public class TestCascadeChoiceParameter {
         assertEquals(expected, param.getParameters());
 
         assertEquals(Arrays.asList("param001", "param002"), Arrays.asList(param.getReferencedParametersAsArray()));
+    }
+
+    @Test
+    public void testNullFilterable() {
+        GroovyScript script = new GroovyScript(new SecureGroovyScript(SCRIPT, Boolean.FALSE, null),
+                new SecureGroovyScript(FALLBACK_SCRIPT, Boolean.FALSE, null));
+        CascadeChoiceParameter param = new CascadeChoiceParameter("param000", "description", "some-random-name", script,
+                CascadeChoiceParameter.ELEMENT_TYPE_FORMATTED_HIDDEN_HTML, "param001, param002", null, 5);
+
+        assertEquals("param000", param.getName());
+        assertEquals("description", param.getDescription());
+        assertEquals("some-random-name", param.getRandomName());
+        assertEquals(script, param.getScript());
+        assertEquals("ET_FORMATTED_HIDDEN_HTML", param.getChoiceType());
+        assertEquals("param001, param002", param.getReferencedParameters());
+        assertFalse(param.getFilterable());
+        assertEquals(Integer.valueOf(5), param.getFilterLength());
     }
 
 }

--- a/src/test/java/org/biouno/unochoice/TestChoiceParameter.java
+++ b/src/test/java/org/biouno/unochoice/TestChoiceParameter.java
@@ -25,6 +25,7 @@
 package org.biouno.unochoice;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.biouno.unochoice.model.GroovyScript;
@@ -63,6 +64,22 @@ public class TestChoiceParameter {
         assertEquals(script, param.getScript());
         assertEquals("ET_FORMATTED_HIDDEN_HTML", param.getChoiceType());
         assertTrue(param.getFilterable());
+        assertEquals(Integer.valueOf(5), param.getFilterLength());
+    }
+
+    @Test
+    public void testNullFilterable() {
+        GroovyScript script = new GroovyScript(new SecureGroovyScript(SCRIPT, Boolean.FALSE, null),
+                new SecureGroovyScript(FALLBACK_SCRIPT, Boolean.FALSE, null));
+        ChoiceParameter param = new ChoiceParameter("param000", "description", "some-random-name", script,
+                CascadeChoiceParameter.ELEMENT_TYPE_FORMATTED_HIDDEN_HTML, false, 5);
+
+        assertEquals("param000", param.getName());
+        assertEquals("description", param.getDescription());
+        assertEquals("some-random-name", param.getRandomName());
+        assertEquals(script, param.getScript());
+        assertEquals("ET_FORMATTED_HIDDEN_HTML", param.getChoiceType());
+        assertFalse(param.getFilterable());
         assertEquals(Integer.valueOf(5), param.getFilterLength());
     }
 }

--- a/src/test/java/org/biouno/unochoice/TestDynamicReferenceParameter.java
+++ b/src/test/java/org/biouno/unochoice/TestDynamicReferenceParameter.java
@@ -25,6 +25,7 @@
 package org.biouno.unochoice;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import org.biouno.unochoice.model.GroovyScript;
@@ -64,6 +65,22 @@ public class TestDynamicReferenceParameter {
         assertEquals("ET_FORMATTED_HIDDEN_HTML", param.getChoiceType());
         assertEquals("param001, param002", param.getReferencedParameters());
         assertTrue(param.getOmitValueField());
+    }
+
+    @Test
+    public void testNullOmitValueField() {
+        GroovyScript script = new GroovyScript(new SecureGroovyScript(SCRIPT, Boolean.FALSE, null),
+                new SecureGroovyScript(FALLBACK_SCRIPT, Boolean.FALSE, null));
+        DynamicReferenceParameter param = new DynamicReferenceParameter("param000", "description", "some-random-name",
+                script, CascadeChoiceParameter.ELEMENT_TYPE_FORMATTED_HIDDEN_HTML, "param001, param002", null);
+
+        assertEquals("param000", param.getName());
+        assertEquals("description", param.getDescription());
+        assertEquals(script, param.getScript());
+        assertEquals("some-random-name", param.getRandomName());
+        assertEquals("ET_FORMATTED_HIDDEN_HTML", param.getChoiceType());
+        assertEquals("param001, param002", param.getReferencedParameters());
+        assertFalse(param.getOmitValueField());
     }
 
 }


### PR DESCRIPTION
When using pipelines, people tend to skip `filterable` as a parameter. That causes `filterable` to be set to `null`. Stapler would emit an empty string.

The prior behavior used javascript truthiness and treated it as `false`.

Since moving almost all javascript into separate files, the new behavior causes an empty string to be printed during the method call.

This change guarantees we emit a primitive `boolean` instead of a boxed `Boolean`.

Refs: [JENKINS-71724](https://issues.jenkins.io/browse/JENKINS-71724)

<!-- Please describe your pull request here. -->

### Testing done

Added new tests.
Existing tests pass.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
