### PR TITLE
JENKINS-72213 : Add a waiting spinner during parameter building

### DIFF
--- a/src/main/resources/org/biouno/unochoice/DynamicReferenceParameter/index.jelly
+++ b/src/main/resources/org/biouno/unochoice/DynamicReferenceParameter/index.jelly
@@ -1,5 +1,5 @@
 <?jelly escape-by-default='true' ?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:l="/lib/layout">
   ${it.parameters.clear()}
   <st:adjunct includes="io.jenkins.plugins.jquery3"/>
   <st:adjunct includes="org.biouno.unochoice.stapler.unochoice"/>
@@ -16,6 +16,9 @@
     <j:set var="cssclazz" value="hidden_uno_choice_parameter" />    
   </j:if>
   <f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
+    <div id='${paramName}-spinner' style="display: none; position: absolute; margin-left: -25px;">
+      <l:spinner />
+    </div>
     <div name="parameter" class="${cssclazz}" id='${paramName}'>
       <input type="hidden" name="name" value="${h.escape(it.name)}" />
       <j:choose>
@@ -62,5 +65,15 @@
     </j:forEach>
 
     UnoChoice.renderDynamicRenderParameter('#${paramName}', '${h.escape(it.getName())}', '${h.escape(paramName)}', referencedParameters, dynamicReferenceParameter);
+
+    // update spinner id
+    let rootElmt = document.querySelector('#${paramName}');
+    if (rootElmt) {
+      let divElmt = rootElmt.querySelector('div');
+      if (divElmt) {
+        let spinnerId = divElmt.id.split('_').pop();
+        document.querySelector('#${paramName}-spinner').setAttribute('id', spinnerId + '-spinner');
+      }
+    }
   </script>
 </j:jelly>

--- a/src/main/resources/org/biouno/unochoice/common/choiceParameterCommon.jelly
+++ b/src/main/resources/org/biouno/unochoice/common/choiceParameterCommon.jelly
@@ -1,11 +1,14 @@
 <?jelly escape-by-default='true'?>
-<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form">
+<j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:f="/lib/form" xmlns:l="/lib/layout">
   <st:adjunct includes="io.jenkins.plugins.jquery3"/>
   <st:adjunct includes="org.biouno.unochoice.stapler.unochoice"/>
   <j:set var="paramName" value="${h.escape(it.randomName)}" scope="parent" />
   <j:set var="choiceType" value="${it.choiceType}"/>
   <j:set var="escapeEntryTitleAndDescription" value="false"/>
   <f:entry title="${h.escape(it.name)}" description="${it.formattedDescription}">
+    <div id='${paramName}-spinner' style="display: none; position: absolute; margin-left: -25px;">
+      <l:spinner />
+    </div>
     <div name="parameter" description="${it.formattedDescription}" id='${paramName}' class="active-choice">
       <input type="hidden" name="name" value="${h.escape(it.name)}" />
       <j:choose>

--- a/src/main/resources/org/biouno/unochoice/stapler/unochoice/UnoChoice.es6
+++ b/src/main/resources/org/biouno/unochoice/stapler/unochoice/UnoChoice.es6
@@ -149,6 +149,22 @@ var UnoChoice = UnoChoice || ($ => {
         console.log(`Values retrieved from Referenced Parameters: ${parametersString}`);
         // Update the CascadeChoiceParameter Map of parameters
         await new Promise((resolve) => this.proxy.doUpdate(parametersString, t => resolve(t)));
+
+        let spinner, rootDiv;
+        if (this.getRandomName()) {
+            let spinnerId = this.getRandomName().split('_').pop();
+            spinner = jQuery(`div#${spinnerId}-spinner`);
+            // Show spinner
+            if (spinner) {
+                spinner.show();
+            }
+            // Disable DIV changes
+            rootDiv = jQuery(`div#${spinnerId}`);
+            if (rootDiv) {
+                rootDiv.css('pointer-events', 'none');
+            }
+        }
+
         // Now we get the updated choices, after the Groovy script is eval'd using the updated Map of parameters
         // The inner function is called with the response provided by Stapler. Then we update the HTML elements.
         let _self = this; // re-reference this to use within the inner function
@@ -314,6 +330,14 @@ var UnoChoice = UnoChoice || ($ => {
         } else {
             console.log('Avoiding infinite loop due to recursion!');
         }
+        // Hide spinner
+        if (spinner) {
+            spinner.hide();
+        }
+        // Activate DIV changes
+        if (rootDiv) {
+            rootDiv.css('pointer-events', 'auto');
+        }
     }
     /**
      * Returns <code>true</code> iff the given parameter is not null, and one of its
@@ -419,6 +443,21 @@ var UnoChoice = UnoChoice || ($ => {
         // Update the Map of parameters
         await new Promise((resolve) => this.proxy.doUpdate(parametersString, t => resolve(t)));
         let parameterElement = this.getParameterElement();
+
+        let spinner, rootDiv;
+        if (parameterElement.id) {
+            let spinnerId = parameterElement.id.split('_').pop();
+            spinner = jQuery(`div#${spinnerId}-spinner`);
+            // Show spinner
+            if (spinner) {
+                spinner.show();
+            }
+            rootDiv = jQuery(`div#${spinnerId}`);
+            // Disable DIV changes
+            if (rootDiv) {
+                rootDiv.css('pointer-events', 'none');
+            }
+        }
         // Here depending on the HTML element we might need to call a method to return a Map of elements,
         // or maybe call a string to put as value in a INPUT.
         if (parameterElement.tagName === 'OL') { // handle OL's
@@ -478,6 +517,14 @@ var UnoChoice = UnoChoice || ($ => {
             }
         } else {
             console.log('Avoiding infinite loop due to recursion!');
+        }
+        // Hide spinner
+        if (spinner) {
+            spinner.hide();
+        }
+        // Activate DIV changes
+        if (rootDiv) {
+            rootDiv.css('pointer-events', 'auto');
         }
     }
     // --- Filter Element
@@ -788,7 +835,6 @@ var UnoChoice = UnoChoice || ($ => {
                     console.log('Filter error: Missing filter element!');
                 }
             }
-
             for (let i  = 0; i < referencedParameters.length ; ++i) {
                 let parameterElement = null;
                 // FIXME: review the block below

--- a/src/test/java/org/biouno/unochoice/UiAcceptanceTest.java
+++ b/src/test/java/org/biouno/unochoice/UiAcceptanceTest.java
@@ -70,7 +70,7 @@ public class UiAcceptanceTest {
             driver = new ChromeDriver(new ChromeOptions());
         }
         wait = new WebDriverWait(driver, MAX_WAIT);
-        driver.manage().window().setSize(new Dimension(1440, 900));
+        driver.manage().window().setSize(new Dimension(2560, 1440));
     }
 
     @After

--- a/src/test/java/org/biouno/unochoice/jenkins_cert_1954/TestParametersXssVulnerabilities.java
+++ b/src/test/java/org/biouno/unochoice/jenkins_cert_1954/TestParametersXssVulnerabilities.java
@@ -23,9 +23,8 @@
  */
 package org.biouno.unochoice.jenkins_cert_1954;
 
-import org.htmlunit.html.DomElement;
-import org.htmlunit.html.DomNodeList;
-import org.htmlunit.html.HtmlPage;
+import org.apache.commons.io.IOUtils;
+import org.htmlunit.html.*;
 import hudson.model.FreeStyleProject;
 import hudson.model.ParametersDefinitionProperty;
 import hudson.util.VersionNumber;
@@ -39,7 +38,9 @@ import org.jvnet.hudson.test.JenkinsRule;
 import org.jvnet.hudson.test.JenkinsRule.WebClient;
 import org.xml.sax.SAXException;
 
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 
 import static org.junit.Assert.assertTrue;
@@ -92,7 +93,18 @@ public class TestParametersXssVulnerabilities {
                 }
             }
             assertNotNull("Could not locate rendered parameter element", renderedParameterElement);
-            String renderedText = renderedParameterElement.getFirstChild().asXml();
+
+            DomNode firstChild = null;
+            for (DomNode child : renderedParameterElement.getChildren()) {
+                // Spinner element must be ignored
+                firstChild = child;
+                if (child instanceof HtmlDivision && ((HtmlDivision) child).getAttribute("id").endsWith("-spinner")) {
+                    continue;
+                }
+                break;
+            }
+            assertNotNull("Could not locate first child element", firstChild);
+            String renderedText = firstChild.asXml();
             assertNotEquals("XSS string was not escaped!", xssString, renderedText);
             assertTrue("XSS string was not escaped!", renderedText.trim().contains("&amp;lt;img src=x onerror=alert(123)&amp;gt;"));
         }


### PR DESCRIPTION
This PR show a waiting spinner at the beginning of update parameter method and hide it at the end.  
I am not totally satisfy about the spinner position (other item's positions are impacted by visibility changes) but my js-knowledge is not good enough to make it better.  

I use this pipeline to test the wanted comportement.  
```groovy
properties([
  parameters([
    [
      name: 'States',
      $class: 'ChoiceParameter',
      choiceType: 'PT_SINGLE_SELECT',
      description: 'Choose a state',
      script: [
        $class: 'GroovyScript',
        script: [sandbox:false, script: '''return ['Sao Paulo','Rio de Janeiro','Parana','Acre']''']
      ]
    ],
    [
      name: 'Cities',
      $class: 'CascadeChoiceParameter',
      choiceType: 'PT_SINGLE_SELECT',
      referencedParameters: 'States',
      description: 'Choose a city',
      script: [
        $class: 'GroovyScript',
        script: [sandbox:false, script: '''if (States == "Sao Paulo") {
  sleep(1000)
  return ["Barretos", "Sao Paulo", "Itu"]
} else if (States == "Rio de Janeiro") {
  sleep(2000)
  return ["Rio de Janeiro", "Mangaratiba"]
} else if (States == "Parana") {
  sleep(3000)
  return ["Curitiba", "Ponta Grossa"]
} else if (States == "Acre") {
  sleep(4000)
  return ["Rio Branco", "Acrelandia"]
} else {
  sleep(10000)
  return ["Unknown state"]
}''']
        ]
   ]
 ])
])


pipeline {
    agent any

    stages {
        stage('Hello') {
            steps {
                script {
                    echo "Hello from ${params.Cities}, ${params.States}"
                }
            }
        }
    }
}
```

Feel free to add your improvements.

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
