### PR TITLE
[JENKINS-72936]: Fix index.jelly for DynamicReferenceParameter

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -3,6 +3,7 @@
 ## Version 2.8.3 (2024/03/??)
 
 - Replace EOL JSR 305 annotations with SpotBugs annotations, thanks @basil
+- [JENKINS-72936]: Fix index.jelly for DynamicReferenceParameter, thanks @c3p0-maif
 
 ## Version 2.8.2 (2024/03/26)
 

--- a/src/main/resources/org/biouno/unochoice/DynamicReferenceParameter/index.jelly
+++ b/src/main/resources/org/biouno/unochoice/DynamicReferenceParameter/index.jelly
@@ -67,11 +67,11 @@
     UnoChoice.renderDynamicRenderParameter('#${paramName}', '${h.escape(it.getName())}', '${h.escape(paramName)}', referencedParameters, dynamicReferenceParameter);
 
     // update spinner id
-    let rootElmt = document.querySelector('#${paramName}');
+    var rootElmt = document.querySelector('#${paramName}');
     if (rootElmt) {
-      let divElmt = rootElmt.querySelector('div');
+      var divElmt = rootElmt.querySelector('div');
       if (divElmt) {
-        let spinnerId = divElmt.id.split('_').pop();
+        var spinnerId = divElmt.id.split('_').pop();
         document.querySelector('#${paramName}-spinner').setAttribute('id', spinnerId + '-spinner');
       }
     }


### PR DESCRIPTION
This PR fix an unseen exception (introduced with #163) when multiple dynamique reference parameters are used at the same time.  
In jelly file, var keyword must be used instead of let.

source : https://issues.jenkins.io/browse/JENKINS-72936

### Testing done

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
