### PR TITLE
[JENKINS-74026][JENKINS-74027] Improve CSP compatibility

### DIFF
--- a/src/main/resources/org/biouno/unochoice/CascadeChoiceParameter/cascade-choice-parameter.js
+++ b/src/main/resources/org/biouno/unochoice/CascadeChoiceParameter/cascade-choice-parameter.js
@@ -1,0 +1,20 @@
+if (window.makeStaplerProxy) {
+    window.__old__makeStaplerProxy = window.makeStaplerProxy;
+    window.makeStaplerProxy = UnoChoice.makeStaplerProxy2;
+}
+
+window.addEventListener("DOMContentLoaded", () => {
+    document.querySelectorAll(".cascade-choice-parameter-data-holder").forEach((dataHolder) => {
+        const { name, paramName, randomName, proxyName } = dataHolder.dataset;
+        const referencedParameters = dataHolder.dataset.referencedParameters.split(",").map((val) => val.trim());
+        const filterable = dataHolder.dataset.filterable === "true";
+        const filterLength = parseInt(dataHolder.dataset.filterLength);
+
+        UnoChoice.renderCascadeChoiceParameter(`#${paramName}`, filterable, name, randomName, filterLength, paramName, referencedParameters, window[proxyName]);
+    });
+
+    if (window.makeStaplerProxy && window.__old__makeStaplerProxy) {
+        window.makeStaplerProxy = window.__old__makeStaplerProxy;
+        delete window["__old__makeStaplerProxy"];
+    }
+});

--- a/src/main/resources/org/biouno/unochoice/CascadeChoiceParameter/index.jelly
+++ b/src/main/resources/org/biouno/unochoice/CascadeChoiceParameter/index.jelly
@@ -2,24 +2,15 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler">
   ${it.parameters.clear()}
   <st:include page="/org/biouno/unochoice/common/choiceParameterCommon.jelly"/>
-  <st:bind value="${it}" var="cascadeChoiceParameter"/>
-  <script type="text/javascript">
-    // source, references table
-    var referencedParameters = Array();
-    <j:forEach var="value" items="${it.getReferencedParametersAsArray()}">
-    // add the element we want to monitor
-    referencedParameters.push("${value}");
-    </j:forEach>
-
-    if (window.makeStaplerProxy) {
-        window.__old__makeStaplerProxy = window.makeStaplerProxy;
-        window.makeStaplerProxy = UnoChoice.makeStaplerProxy2;
-    }
-    var cascadeChoiceParameter = <st:bind value="${it}"/>; // Create Jenkins proxy
-    if (window.makeStaplerProxy) {
-        window.makeStaplerProxy = window.__old__makeStaplerProxy;
-    }
-    UnoChoice.renderCascadeChoiceParameter('#${h.escape(paramName)}', ${it.filterable}, '${h.escape(it.getName())}', '${h.escape(it.getRandomName())}', ${it.getFilterLength()}, '${h.escape(paramName)}', referencedParameters, cascadeChoiceParameter);
-
-  </script>
+  <j:set var="proxyName" value="cascadeChoiceParameter_${h.generateId()}"/>
+  <span class="cascade-choice-parameter-data-holder"
+          data-proxy-name="${proxyName}"
+          data-referenced-parameters="${it.getReferencedParameters()}"
+          data-param-name="${h.escape(paramName)}"
+          data-name="${h.escape(it.getName())}"
+          data-filterable="${it.filterable}"
+          data-random-name="${h.escape(it.getRandomName())}"
+          data-filter-length="${it.getFilterLength()}"/>
+  <st:adjunct includes="org.biouno.unochoice.CascadeChoiceParameter.cascade-choice-parameter"/>
+  <st:bind value="${it}" var="${proxyName}"/>
 </j:jelly>

--- a/src/main/resources/org/biouno/unochoice/DynamicReferenceParameter/dynamic-reference-parameter.js
+++ b/src/main/resources/org/biouno/unochoice/DynamicReferenceParameter/dynamic-reference-parameter.js
@@ -1,0 +1,28 @@
+if (window.makeStaplerProxy) {
+    window.__old__makeStaplerProxy = window.makeStaplerProxy;
+    window.makeStaplerProxy = UnoChoice.makeStaplerProxy2;
+}
+
+window.addEventListener("DOMContentLoaded", () => {
+    document.querySelectorAll(".dynamic-reference-parameter-data-holder").forEach((dataHolder) => {
+        const { name, paramName, proxyName } = dataHolder.dataset;
+        const referencedParameters = dataHolder.dataset.referencedParameters.split(",").map((val) => val.trim());
+
+        UnoChoice.renderDynamicRenderParameter(`#${paramName}`, name, paramName, referencedParameters, window[proxyName]);
+
+        // update spinner id
+        var rootElmt = document.querySelector(`#${paramName}`);
+        if (rootElmt) {
+            var divElmt = rootElmt.querySelector("div");
+            if (divElmt) {
+                var spinnerId = divElmt.id.split("_").pop();
+                document.querySelector(`#${paramName}-spinner`).setAttribute("id", spinnerId + "-spinner");
+            }
+        }
+    });
+
+    if (window.makeStaplerProxy && window.__old__makeStaplerProxy) {
+        window.makeStaplerProxy = window.__old__makeStaplerProxy;
+        delete window["__old__makeStaplerProxy"];
+    }
+});

--- a/src/main/resources/org/biouno/unochoice/DynamicReferenceParameter/index.jelly
+++ b/src/main/resources/org/biouno/unochoice/DynamicReferenceParameter/index.jelly
@@ -55,33 +55,12 @@
       </j:choose>
     </div>
   </f:entry>
-  <st:bind value="${it}" var="dynamicReferenceParameter"/>
-  <script type="text/javascript">
-    // source, references table
-    var referencedParameters = Array();
-    <j:forEach var="value" items="${it.getReferencedParametersAsArray()}">
-    // add the element we want to monitor
-    referencedParameters.push("${value}");
-    </j:forEach>
-
-    if (window.makeStaplerProxy) {
-        window.__old__makeStaplerProxy = window.makeStaplerProxy;
-        window.makeStaplerProxy = UnoChoice.makeStaplerProxy2;
-    }
-    var dynamicReferenceParameter = <st:bind value="${it}"/>; // Create Jenkins proxy
-    if (window.makeStaplerProxy) {
-        window.makeStaplerProxy = window.__old__makeStaplerProxy;
-    }
-    UnoChoice.renderDynamicRenderParameter('#${paramName}', '${h.escape(it.getName())}', '${h.escape(paramName)}', referencedParameters, dynamicReferenceParameter);
-
-    // update spinner id
-    var rootElmt = document.querySelector('#${paramName}');
-    if (rootElmt) {
-      var divElmt = rootElmt.querySelector('div');
-      if (divElmt) {
-        var spinnerId = divElmt.id.split('_').pop();
-        document.querySelector('#${paramName}-spinner').setAttribute('id', spinnerId + '-spinner');
-      }
-    }
-  </script>
+  <j:set var="proxyName" value="dynamicReferenceParameter_${h.generateId()}"/>
+  <span class="dynamic-reference-parameter-data-holder"
+          data-proxy-name="${proxyName}"
+          data-referenced-parameters="${it.getReferencedParameters()}"
+          data-param-name="${paramName}"
+          data-name="${h.escape(it.getName())}"/>
+  <st:adjunct includes="org.biouno.unochoice.DynamicReferenceParameter.dynamic-reference-parameter"/>
+  <st:bind value="${it}" var="${proxyName}"/>
 </j:jelly>

--- a/src/test/java/org/biouno/unochoice/jenkins_cert_2008/TestGroovyScriptXssVulnerabilities.java
+++ b/src/test/java/org/biouno/unochoice/jenkins_cert_2008/TestGroovyScriptXssVulnerabilities.java
@@ -149,7 +149,7 @@ public class TestGroovyScriptXssVulnerabilities {
                 "random-name",
                 script,
                 DynamicReferenceParameter.ELEMENT_TYPE_FORMATTED_HTML,
-                null,
+                "",
                 false);
         project.addProperty(new ParametersDefinitionProperty(parameter));
         project.save();


### PR DESCRIPTION
- Extract inline JavaScript from `DynamicReferenceParameter/index.jelly`
- Extract inline JavaScript from `CascadeChoiceParameter/index.jelly`

<!-- Please describe your pull request here. -->
https://issues.jenkins.io/browse/JENKINS-74026
https://issues.jenkins.io/browse/JENKINS-74027

### Testing done

I've relied a lot on the scenario from https://issues.jenkins.io/browse/JENKINS-71909. Made sure that isn't broken. Unit test that asserts that behavior is very much appreciated, helped me a lot along the way. I feel like I'm almost over relying on it though.

[Before the fix](https://www.youtube.com/watch?v=uctGEYAXXYY)
[After the fix](https://www.youtube.com/watch?v=GCH3wqcMHUk)

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests - that demonstrates feature works or fixes the issue

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
