### PR TITLE
Implement `Describable` from `Script`, not `AbstractScript`

### DIFF
--- a/src/main/java/org/biouno/unochoice/UnoChoiceParameterDescriptor.java
+++ b/src/main/java/org/biouno/unochoice/UnoChoiceParameterDescriptor.java
@@ -27,7 +27,7 @@ package org.biouno.unochoice;
 import java.util.LinkedList;
 import java.util.List;
 
-import org.biouno.unochoice.model.AbstractScript;
+import org.biouno.unochoice.model.Script;
 
 import hudson.model.Descriptor;
 import hudson.model.ParameterDefinition.ParameterDescriptor;
@@ -40,8 +40,8 @@ import hudson.model.ParameterDefinition.ParameterDescriptor;
  */
 public class UnoChoiceParameterDescriptor extends ParameterDescriptor {
 
-    public List<Descriptor<? extends AbstractScript>> getApplicableResultSeekers() {
-        return new LinkedList<>(AbstractScript.all());
+    public List<Descriptor<? extends Script>> getApplicableResultSeekers() {
+        return new LinkedList<>(Script.all());
     }
 
 }

--- a/src/main/java/org/biouno/unochoice/model/AbstractScript.java
+++ b/src/main/java/org/biouno/unochoice/model/AbstractScript.java
@@ -24,8 +24,6 @@
 
 package org.biouno.unochoice.model;
 
-import hudson.DescriptorExtensionList;
-import hudson.model.Describable;
 import hudson.model.Descriptor;
 import jenkins.model.Jenkins;
 
@@ -35,31 +33,27 @@ import jenkins.model.Jenkins;
  * @author Bruno P. Kinoshita
  * @since 0.23
  */
-public abstract class AbstractScript implements Script, Describable<AbstractScript> {
+public abstract class AbstractScript implements Script {
 
     /*
      * Serial UID.
      */
     private static final long serialVersionUID = 4027103576278802323L;
 
+    // TODO could be pulled up into Script (default method);
+    // in fact this intermediate type could probably be deleted
+    // (assuming there is no Java serialization outside of Remoting,
+    // since such a change would break the stream class description;
+    // XStream should not care about that)
     @Override
     @SuppressWarnings("unchecked")
-    public Descriptor<AbstractScript> getDescriptor() {
+    public Descriptor<Script> getDescriptor() {
         final Jenkins instance = Jenkins.getInstanceOrNull();
-        Descriptor<AbstractScript> descriptor = null;
+        Descriptor<Script> descriptor = null;
         if (instance != null) {
             descriptor = instance.getDescriptor(getClass());
         }
         return descriptor;
-    }
-
-    public static DescriptorExtensionList<AbstractScript, ScriptDescriptor> all() {
-        final Jenkins instance = Jenkins.getInstanceOrNull();
-        DescriptorExtensionList<AbstractScript, ScriptDescriptor> all = null;
-        if (instance != null) {
-            all = instance.getDescriptorList(AbstractScript.class);
-        }
-        return all;
     }
 
 }

--- a/src/main/java/org/biouno/unochoice/model/Script.java
+++ b/src/main/java/org/biouno/unochoice/model/Script.java
@@ -24,8 +24,11 @@
 
 package org.biouno.unochoice.model;
 
+import hudson.DescriptorExtensionList;
+import hudson.model.Describable;
 import java.io.Serializable;
 import java.util.Map;
+import jenkins.model.Jenkins;
 
 /**
  * Interface for scripts.
@@ -33,7 +36,7 @@ import java.util.Map;
  * @author Bruno P. Kinoshita
  * @since 0.23
  */
-public interface Script extends Serializable {
+public interface Script extends Serializable, Describable<Script> {
 
     /**
      * Evaluates the script.
@@ -49,5 +52,14 @@ public interface Script extends Serializable {
      * @return output of the script
      */
     Object eval(Map<String, String> parameters);
+
+    static DescriptorExtensionList<Script, ScriptDescriptor> all() {
+        final Jenkins instance = Jenkins.getInstanceOrNull();
+        DescriptorExtensionList<Script, ScriptDescriptor> all = null;
+        if (instance != null) {
+            all = instance.getDescriptorList(Script.class);
+        }
+        return all;
+    }
 
 }

--- a/src/main/java/org/biouno/unochoice/model/ScriptDescriptor.java
+++ b/src/main/java/org/biouno/unochoice/model/ScriptDescriptor.java
@@ -32,6 +32,6 @@ import hudson.model.Descriptor;
  * @author Bruno P. Kinoshita
  * @since 0.23
  */
-public abstract class ScriptDescriptor extends Descriptor<AbstractScript> {
+public abstract class ScriptDescriptor extends Descriptor<Script> {
 
 }


### PR DESCRIPTION
Since this is used as the declared type of a nested field in higher `Describable`s, https://github.com/jenkinsci/active-choices-plugin/blob/59bda8415ce02e07125e1aa350e26f6be4bee9ed/src/main/java/org/biouno/unochoice/CascadeChoiceParameter.java#L125-L126 for example, it is mandatory to show that it is `Describable`.