### PR TITLE
JENKINS-75593: Use empty string for undefined referencedParameters

### DIFF
--- a/src/main/resources/org/biouno/unochoice/CascadeChoiceParameter/cascade-choice-parameter.js
+++ b/src/main/resources/org/biouno/unochoice/CascadeChoiceParameter/cascade-choice-parameter.js
@@ -6,12 +6,8 @@ if (window.makeStaplerProxy) {
 window.addEventListener("DOMContentLoaded", () => {
     document.querySelectorAll(".cascade-choice-parameter-data-holder").forEach((dataHolder) => {
         const { name, paramName, randomName, proxyName } = dataHolder.dataset;
-        const referencedParameters = dataHolder.dataset.referencedParameters;
-        if (referencedParameters === undefined || referencedParameters === null || referencedParameters.length === 0) {
-            console.log(`[${name}] - cascade-choice-parameters.js#querySelectorAll#forEach - No parameters referenced!`);
-            return;
-        }
-        const referencedParametersList = dataHolder.dataset.referencedParameters.split(",").map((val) => val.trim());
+        const referencedParameters = dataHolder.dataset.referencedParameters || '';
+        const referencedParametersList = referencedParameters.split(",").map((val) => val.trim());
         const filterable = dataHolder.dataset.filterable === "true";
         const filterLength = parseInt(dataHolder.dataset.filterLength);
 

--- a/src/main/resources/org/biouno/unochoice/DynamicReferenceParameter/dynamic-reference-parameter.js
+++ b/src/main/resources/org/biouno/unochoice/DynamicReferenceParameter/dynamic-reference-parameter.js
@@ -6,12 +6,8 @@ if (window.makeStaplerProxy) {
 window.addEventListener("DOMContentLoaded", () => {
     document.querySelectorAll(".dynamic-reference-parameter-data-holder").forEach((dataHolder) => {
         const { name, paramName, proxyName } = dataHolder.dataset;
-        const referencedParameters = dataHolder.dataset.referencedParameters;
-        if (referencedParameters === undefined || referencedParameters === null || referencedParameters.length === 0) {
-            console.log(`[${name}] - dynamic-reference-parameter.js#querySelectorAll#forEach - No parameters referenced!`);
-            return;
-        }
-        const referencedParametersList = dataHolder.dataset.referencedParameters.split(",").map((val) => val.trim());
+        const referencedParameters = dataHolder.dataset.referencedParameters || '';
+        const referencedParametersList = referencedParameters.split(",").map((val) => val.trim());
 
         UnoChoice.renderDynamicRenderParameter(`#${paramName}`, name, paramName, referencedParametersList, window[proxyName]);
 


### PR DESCRIPTION
The change in https://github.com/jenkinsci/active-choices-plugin/pull/467 has caused parameters without referenced parameters to no longer render correctly in certain conditions:

1. Reactive Reference Parameter set as Hidden HTML is not being hidden ([JENKINS-75593](https://issues.jenkins.io/browse/JENKINS-75593))
2. Filtering for Reactive Parameter doesn't function ([JENKINS-75660](https://issues.jenkins.io/browse/JENKINS-75660))

While it seems uncommon to use a Reactive Parameter without references, I rely on Reactive Reference parameters with no references for hidden values or to trigger custom JavaScript.

The undefined errors seem to only occur in pipelines. In freestyle jobs the value is an empty string if there are no referenced parameters. I'm thinking it should default to an empty string in both cases. This would maintain consistency between job types and prevent JS errors when accessing the referencedParameters property.

I can add some tests if this is an acceptable solution.

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed