### PR TITLE
Fixed CascadeChoiceParameter with RADIO choice type both in classic UI and new job page

### DIFF
--- a/src/main/js/UnoChoice.es6
+++ b/src/main/js/UnoChoice.es6
@@ -319,7 +319,9 @@ var UnoChoice = UnoChoice || (jQuery3 => {
                             idValue = idValue.replace(' ', '_');
                             // <INPUT>
                             let input = util.makeRadio(key, _self.getParameterName(), selectedElements.indexOf(i) >= 0, disabledElements.indexOf(i) >= 0);
-                            input.setAttribute('onchange', `UnoChoice.fakeSelectRadioButton("${_self.getParameterName()}", "${idValue}")`);
+                                input.addEventListener('change', function () {
+                                fakeSelectRadioButton(_self.getParameterName(), idValue);
+                            });
                             input.setAttribute('otherId', idValue);
                             if (!entry instanceof String) {
                                 input.setAttribute('alt', JSON.stringify(entry));

--- a/src/main/resources/org/biouno/unochoice/CascadeChoiceParameter/cascade-choice-parameter.js
+++ b/src/main/resources/org/biouno/unochoice/CascadeChoiceParameter/cascade-choice-parameter.js
@@ -1,25 +1,14 @@
-if (window.makeStaplerProxy) {
-    window.__old__makeStaplerProxy = window.makeStaplerProxy;
-    window.makeStaplerProxy = UnoChoice.makeStaplerProxy2;
-}
-
-window.addEventListener("DOMContentLoaded", () => {
-    document.querySelectorAll(".cascade-choice-parameter-data-holder").forEach((dataHolder) => {
-        const { name, paramName, randomName, proxyName } = dataHolder.dataset;
-        const referencedParameters = dataHolder.dataset.referencedParameters;
-        if (referencedParameters === undefined || referencedParameters === null || referencedParameters.length === 0) {
-            console.log(`[${name}] - cascade-choice-parameters.js#querySelectorAll#forEach - No parameters referenced!`);
-            return;
-        }
-        const referencedParametersList = dataHolder.dataset.referencedParameters.split(",").map((val) => val.trim());
-        const filterable = dataHolder.dataset.filterable === "true";
-        const filterLength = parseInt(dataHolder.dataset.filterLength);
-
-        UnoChoice.renderCascadeChoiceParameter(`#${paramName}`, filterable, name, randomName, filterLength, paramName, referencedParametersList, window[proxyName]);
-    });
-
-    if (window.makeStaplerProxy && window.__old__makeStaplerProxy) {
-        window.makeStaplerProxy = window.__old__makeStaplerProxy;
-        delete window["__old__makeStaplerProxy"];
+Behaviour.specify(".cascade-choice-parameter-data-holder", "uno-choice-cascade", 0, function (dataHolder) {
+    const { name, paramName, randomName, proxyName } = dataHolder.dataset;
+    const referencedParameters = dataHolder.dataset.referencedParameters;
+    if (referencedParameters === undefined || referencedParameters === null || referencedParameters.length === 0) {
+        console.log(`[${name}] - cascade-choice-parameters.js#querySelectorAll#forEach - No parameters referenced!`);
+        return;
     }
+    const referencedParametersList = dataHolder.dataset.referencedParameters.split(",").map((val) => val.trim());
+    const filterable = dataHolder.dataset.filterable === "true";
+    const filterLength = parseInt(dataHolder.dataset.filterLength);
+
+    UnoChoice.renderCascadeChoiceParameter(`#${paramName}`, filterable, name, randomName, filterLength, paramName, referencedParametersList, window[proxyName]);
 });
+


### PR DESCRIPTION
<!-- Please describe your pull request here. -->
Fixed the issue #929 cascadeChoiceParameter with radio choice type bug which was occurring when we are doing a freeStyle job with choice and active choice reactive parameter.  

### Testing done
Created a Freestyle Job with name: test-groovy-script-radio-bug-repro
added first parameter as choice type with 
Name: ENVIRONMENT
Choices:
development
staging
production
and second Parameter of type Active Choices Reactive Parameter with 
Name: CONFIG_FILE
Choice Type: Radio Buttons
Referenced parameters: ENVIRONMENT and also add a Groovy Script:

if (ENVIRONMENT.equals("development")) {
    return ["dev-config-1.yaml", "dev-config-2.yaml", "dev-config-3.yaml"]
} 
else if (ENVIRONMENT.equals("staging")) {
    return ["staging-config-1.yaml", "staging-config-2.yaml"]
} 
else if (ENVIRONMENT.equals("production")) {
    return ["prod-config-1.yaml", "prod-config-2.yaml", "prod-config-3.yaml"]
} 
else {
    return ["default-config.yaml"]
}

add a Fallback Script:

return ["fallback-config.yaml"]

and in the build step select execute shell with the script: 

echo "ENVIRONMENT = $ENVIRONMENT"
echo "CONFIG_FILE = $CONFIG_FILE"

if [ -z "$CONFIG_FILE" ]; then
  echo "BUG: CONFIG_FILE is empty"
  exit 1
else
  echo "CONFIG_FILE selected: $CONFIG_FILE"
fi
Saved the job and build with parameters and check the console output
Earlier: 
ENVIRONMENT = development
CONFIG_FILE =
BUG: CONFIG_FILE is empty
After fix applied: 
ENVIRONMENT = development(selected env)
CONFIG_FILE = dev-config-1.yaml (selected option)


<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

### Submitter checklist
- [ ] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [ ] Ensure that the pull request title represents the desired changelog entry
- [ ] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
