### PR TITLE
fix: Override getDefaultParameterValue for Checkbox list

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@
 
 ## Version 2.8.10 (????/??/??)
 
-- Adapt build status icon for ci.jenkins.io permissions change (thanks @MarkEWaite)
+- Adapt the build status icon for ci.jenkins.io permissions change (thanks @MarkEWaite)
 - Adapt to release drafter v7 configuration change (thanks @MarkEWaite)
 - Bump @babel/plugin-transform-modules-systemjs from 7.29.0 to 7.29.4
 - Bump @babel/preset-env from 7.29.0 to 7.29.7
@@ -19,6 +19,7 @@
 - Bump webpack from 5.105.4 to 5.106.2
 - Bump webpack-cli from 7.0.1 to 7.0.2
 - #897 JENKINS-75644 Cache project resolution after UUID fallback (thanks @tzachs)
+- #947 JENKINS-75760 Override getDefaultParameterValue for the checkbox list (thanks @c3p0-maif)
 
 ## Version 2.8.9 (2026/02/16)
 

--- a/src/main/java/org/biouno/unochoice/ChoiceParameter.java
+++ b/src/main/java/org/biouno/unochoice/ChoiceParameter.java
@@ -26,12 +26,17 @@ package org.biouno.unochoice;
 
 import hudson.Extension;
 
+import hudson.model.ParameterValue;
+import hudson.model.StringParameterValue;
+import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
 import org.biouno.unochoice.model.Script;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.jenkinsci.Symbol;
 
-import java.util.Objects;
+import java.util.*;
+import java.util.logging.Level;
+import java.util.regex.Pattern;
 
 /**
  * A parameter that renders its options as a choice (select) HTML component.
@@ -141,6 +146,32 @@ public class ChoiceParameter extends AbstractScriptableParameter {
      */
     public Integer getFilterLength() {
         return filterLength == null ? (Integer) 1 : filterLength;
+    }
+
+    /**
+     * JENKINS-75760 : checkbox list must return empty default value.
+     * @return empty parameterValue
+     */
+    @Override
+    public ParameterValue getDefaultParameterValue() {
+        if (Objects.equals(choiceType, PARAMETER_TYPE_CHECK_BOX)) {
+            final String name = getName();
+            Map<Object, Object> choices = getChoices(Collections.emptyMap());
+            List<String> defaultValues = new ArrayList<>();
+
+            for (Map.Entry<?, ?> entry : choices.entrySet()) {
+                String keyStr = ObjectUtils.toString(entry.getKey());
+                String valueStr = ObjectUtils.toString(entry.getValue());
+                // on split choice sur ':' et on recherche selected
+                String key = Pattern.compile(":").splitAsStream(keyStr).findFirst().orElse(keyStr);
+                List<String> parts = Pattern.compile(":").splitAsStream(valueStr).toList();
+                if (parts.contains("selected")) {
+                    defaultValues.add(key);
+                }
+            }
+            return new StringParameterValue(name, String.join(",", defaultValues));
+        }
+        return super.getDefaultParameterValue();
     }
 
     // --- descriptor

--- a/src/main/java/org/biouno/unochoice/ChoiceParameter.java
+++ b/src/main/java/org/biouno/unochoice/ChoiceParameter.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2020 Ioannis Moutsatsos, Bruno P. Kinoshita
+ * Copyright (c) 2014-2026 Ioannis Moutsatsos, Bruno P. Kinoshita
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,18 +25,18 @@
 package org.biouno.unochoice;
 
 import hudson.Extension;
-
 import hudson.model.ParameterValue;
 import hudson.model.StringParameterValue;
 import org.apache.commons.lang.ObjectUtils;
 import org.apache.commons.lang.StringUtils;
 import org.biouno.unochoice.model.Script;
-import org.kohsuke.stapler.DataBoundConstructor;
 import org.jenkinsci.Symbol;
+import org.kohsuke.stapler.DataBoundConstructor;
 
-import java.util.*;
-import java.util.logging.Level;
-import java.util.regex.Pattern;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 /**
  * A parameter that renders its options as a choice (select) HTML component.
@@ -66,6 +66,11 @@ public class ChoiceParameter extends AbstractScriptableParameter {
      * is activated.
      */
     private final Integer filterLength;
+
+    /**
+     * Constant used for check boxes.
+     */
+    private static final String SELECTED_OPTION = "selected";
 
     /**
      * Constructor called from Jelly with parameters.
@@ -149,27 +154,26 @@ public class ChoiceParameter extends AbstractScriptableParameter {
     }
 
     /**
-     * JENKINS-75760 : checkbox list must return empty default value.
-     * @return empty parameterValue
+     * Returns the default value for this parameter.
+     *
+     * <p>For checkbox parameters (JENKINS-75760), the default value is derived from
+     * the choices marked as selected in the choice metadata. If no choices are
+     * selected, an empty value is returned.</p>
+     *
+     * @return the default parameter value, or a comma-separated list of selected checkbox values
      */
     @Override
     public ParameterValue getDefaultParameterValue() {
         if (Objects.equals(choiceType, PARAMETER_TYPE_CHECK_BOX)) {
             final String name = getName();
-            Map<Object, Object> choices = getChoices(Collections.emptyMap());
-            List<String> defaultValues = new ArrayList<>();
+            final Map<Object, Object> choices = getChoices(Collections.emptyMap());
 
-            for (Map.Entry<?, ?> entry : choices.entrySet()) {
-                String keyStr = ObjectUtils.toString(entry.getKey());
-                String valueStr = ObjectUtils.toString(entry.getValue());
-                // on split choice sur ':' et on recherche selected
-                String key = Pattern.compile(":").splitAsStream(keyStr).findFirst().orElse(keyStr);
-                List<String> parts = Pattern.compile(":").splitAsStream(valueStr).toList();
-                if (parts.contains("selected")) {
-                    defaultValues.add(key);
-                }
-            }
-            return new StringParameterValue(name, String.join(",", defaultValues));
+            final String defaultValue = choices.entrySet().stream()
+                    .filter(entry -> ObjectUtils.toString(entry.getValue()).contains(SELECTED_OPTION))
+                    .map(entry -> ObjectUtils.toString(entry.getKey()).split(":", 2)[0])
+                    .collect(Collectors.joining(","));
+
+            return new StringParameterValue(name, defaultValue);
         }
         return super.getDefaultParameterValue();
     }

--- a/src/test/java/org/biouno/unochoice/issue75760/TestDefaultCheckboxParameters.java
+++ b/src/test/java/org/biouno/unochoice/issue75760/TestDefaultCheckboxParameters.java
@@ -1,0 +1,172 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2023 Ioannis Moutsatsos, Bruno P. Kinoshita
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package org.biouno.unochoice.issue75760;
+
+import hudson.model.queue.QueueTaskFuture;
+import jenkins.plugins.git.junit.jupiter.WithGitSampleRepo;
+import jenkins.plugins.git.traits.BranchDiscoveryTrait;
+import jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait;
+import hudson.model.ParametersDefinitionProperty;
+import jenkins.branch.BranchSource;
+import jenkins.model.Jenkins;
+import jenkins.plugins.git.GitBranchSCMHead;
+import jenkins.plugins.git.GitSCMSource;
+import jenkins.plugins.git.GitSampleRepoRule;
+import jenkins.scm.api.SCMHead;
+import org.biouno.unochoice.AbstractUnoChoiceParameter;
+import org.biouno.unochoice.ChoiceParameter;
+import org.biouno.unochoice.model.GroovyScript;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
+import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
+import org.jenkinsci.plugins.scriptsecurity.scripts.languages.GroovyLanguage;
+import org.jenkinsci.plugins.workflow.job.WorkflowJob;
+import org.jenkinsci.plugins.workflow.job.WorkflowRun;
+import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.*;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+import java.util.List;
+
+import static org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProjectTest.scheduleAndFindBranchProject;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test that a build with no parameter set result on an empty value and not the first choice item.
+ *
+ * @since 2.6.5
+ */
+@Issue("JENKINS-75760")
+@WithJenkins
+@WithGitSampleRepo
+class TestDefaultCheckboxParameters {
+    private JenkinsRule j;
+    private GitSampleRepoRule sampleRepo;
+
+    // LIST script
+    private static final String SCRIPT_TRUSTED = "return ['envA', 'envB', 'envC']";
+    private static final String SCRIPT_NOT_TRUSTED = "return ['env1', 'env2', 'env3']";
+    private static final String SCRIPT_FALLBACK = "return ['error']";
+
+    @BeforeEach
+    void setUp(JenkinsRule j, GitSampleRepoRule sampleRepo) throws Exception {
+        this.j = j;
+        j.jenkins.setSecurityRealm(j.createDummySecurityRealm());
+        j.jenkins.setAuthorizationStrategy(new MockAuthorizationStrategy()
+                .grant(Jenkins.ADMINISTER).everywhere().toEveryone()
+        );
+        ScriptApproval.get().preapprove(SCRIPT_TRUSTED, new GroovyLanguage());
+        ScriptApproval.get().preapprove(SCRIPT_FALLBACK, new GroovyLanguage());
+
+        // create a git repo
+        this.sampleRepo = sampleRepo;
+        sampleRepo.init();
+        sampleRepo.write("Jenkinsfile", "echo 'params=' + params");
+        sampleRepo.git("add", "Jenkinsfile");
+        sampleRepo.git("commit", "--all", "--message=flow");
+    }
+
+    @Test
+    void testCheckboxParamSandbox() throws Exception {
+        // create a multibranch workflow from git repo
+        WorkflowMultiBranchProject mp = j.createProject(WorkflowMultiBranchProject.class, "job1");
+        GitSCMSource gitSCMSource = new GitSCMSource(sampleRepo.toString());
+        gitSCMSource.setTraits(List.of(new BranchDiscoveryTrait(), new WildcardSCMHeadFilterTrait("*", "")));
+        mp.getSourcesList().add(new BranchSource(gitSCMSource));
+        WorkflowJob job = scheduleAndFindBranchProject(mp, "master");
+        assertEquals(new GitBranchSCMHead("master"), SCMHead.HeadByItem.findHead(job));
+        assertEquals(1, mp.getItems().size());
+        j.waitUntilNoActivity();
+
+        // configure groovy scripts
+        GroovyScript script = new GroovyScript(new SecureGroovyScript(SCRIPT_TRUSTED, true, null), new SecureGroovyScript(SCRIPT_FALLBACK, false, null));
+        ChoiceParameter param = new ChoiceParameter("environments", "description", "random-name",
+                script, AbstractUnoChoiceParameter.PARAMETER_TYPE_CHECK_BOX, false, 1);
+        job.addProperty(new ParametersDefinitionProperty(
+                List.of(param)));
+        job.save();
+        j.waitUntilNoActivity();
+
+        QueueTaskFuture<WorkflowRun> future = job.scheduleBuild2(0);
+        WorkflowRun build = j.assertBuildStatusSuccess(future);
+        // check that the build works
+        j.assertLogContains("params=[environments:]", build);
+    }
+
+    @Test
+    void testCheckboxParamTrusted() throws Exception {
+        // create a multibranch workflow from git repo
+        WorkflowMultiBranchProject mp = j.createProject(WorkflowMultiBranchProject.class, "job2");
+        GitSCMSource gitSCMSource = new GitSCMSource(sampleRepo.toString());
+        gitSCMSource.setTraits(List.of(new BranchDiscoveryTrait(), new WildcardSCMHeadFilterTrait("*", "")));
+        mp.getSourcesList().add(new BranchSource(gitSCMSource));
+        WorkflowJob job = scheduleAndFindBranchProject(mp, "master");
+        assertEquals(new GitBranchSCMHead("master"), SCMHead.HeadByItem.findHead(job));
+        assertEquals(1, mp.getItems().size());
+        j.waitUntilNoActivity();
+
+        // configure groovy scripts
+        GroovyScript script = new GroovyScript(new SecureGroovyScript(SCRIPT_TRUSTED, false, null), new SecureGroovyScript(SCRIPT_FALLBACK, false, null));
+        ChoiceParameter param = new ChoiceParameter("environments", "description", "random-name",
+                script, AbstractUnoChoiceParameter.PARAMETER_TYPE_CHECK_BOX, false, 1);
+        job.addProperty(new ParametersDefinitionProperty(
+                List.of(param)));
+        job.save();
+        j.waitUntilNoActivity();
+
+        QueueTaskFuture<WorkflowRun> future = job.scheduleBuild2(0);
+        WorkflowRun build = j.assertBuildStatusSuccess(future);
+        // check that the build works
+        j.assertLogContains("params=[environments:]", build);
+    }
+
+    @Test
+    void testCheckboxParamNotTrusted() throws Exception {
+        // create a multibranch workflow from git repo
+        WorkflowMultiBranchProject mp = j.createProject(WorkflowMultiBranchProject.class, "job3");
+        GitSCMSource gitSCMSource = new GitSCMSource(sampleRepo.toString());
+        gitSCMSource.setTraits(List.of(new BranchDiscoveryTrait(), new WildcardSCMHeadFilterTrait("*", "")));
+        mp.getSourcesList().add(new BranchSource(gitSCMSource));
+        WorkflowJob job = scheduleAndFindBranchProject(mp, "master");
+        assertEquals(new GitBranchSCMHead("master"), SCMHead.HeadByItem.findHead(job));
+        assertEquals(1, mp.getItems().size());
+        j.waitUntilNoActivity();
+
+        // configure groovy scripts
+        GroovyScript script = new GroovyScript(new SecureGroovyScript(SCRIPT_NOT_TRUSTED, false, null), new SecureGroovyScript(SCRIPT_FALLBACK, false, null));
+        ChoiceParameter param = new ChoiceParameter("environments", "description", "random-name",
+                script, AbstractUnoChoiceParameter.PARAMETER_TYPE_CHECK_BOX, false, 1);
+        job.addProperty(new ParametersDefinitionProperty(
+                List.of(param)));
+        job.save();
+        j.waitUntilNoActivity();
+
+        QueueTaskFuture<WorkflowRun> future = job.scheduleBuild2(0);
+        WorkflowRun build = j.assertBuildStatusSuccess(future);
+        // check that the build works
+        j.assertLogContains("params=[environments:]", build);
+    }
+
+}

--- a/src/test/java/org/biouno/unochoice/issue75760/TestDefaultCheckboxParameters.java
+++ b/src/test/java/org/biouno/unochoice/issue75760/TestDefaultCheckboxParameters.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2023 Ioannis Moutsatsos, Bruno P. Kinoshita
+ * Copyright (c) 2014-2026 Ioannis Moutsatsos, Bruno P. Kinoshita
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,17 +23,17 @@
  */
 package org.biouno.unochoice.issue75760;
 
-import hudson.model.queue.QueueTaskFuture;
-import jenkins.plugins.git.junit.jupiter.WithGitSampleRepo;
-import jenkins.plugins.git.traits.BranchDiscoveryTrait;
-import jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait;
 import hudson.model.ParametersDefinitionProperty;
+import hudson.model.queue.QueueTaskFuture;
 import jenkins.branch.BranchSource;
 import jenkins.model.Jenkins;
 import jenkins.plugins.git.GitBranchSCMHead;
 import jenkins.plugins.git.GitSCMSource;
 import jenkins.plugins.git.GitSampleRepoRule;
+import jenkins.plugins.git.junit.jupiter.WithGitSampleRepo;
+import jenkins.plugins.git.traits.BranchDiscoveryTrait;
 import jenkins.scm.api.SCMHead;
+import jenkins.scm.impl.trait.WildcardSCMHeadFilterTrait;
 import org.biouno.unochoice.AbstractUnoChoiceParameter;
 import org.biouno.unochoice.ChoiceParameter;
 import org.biouno.unochoice.model.GroovyScript;
@@ -45,7 +45,9 @@ import org.jenkinsci.plugins.workflow.job.WorkflowRun;
 import org.jenkinsci.plugins.workflow.multibranch.WorkflowMultiBranchProject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.jvnet.hudson.test.*;
+import org.jvnet.hudson.test.Issue;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.MockAuthorizationStrategy;
 import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
 
 import java.util.List;
@@ -56,7 +58,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 /**
  * Test that a build with no parameter set result on an empty value and not the first choice item.
  *
- * @since 2.6.5
+ * @since 2.8.10
  */
 @Issue("JENKINS-75760")
 @WithJenkins

--- a/src/test/java/org/biouno/unochoice/issue75760/package-info.java
+++ b/src/test/java/org/biouno/unochoice/issue75760/package-info.java
@@ -1,0 +1,30 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2025 Ioannis Moutsatsos, Bruno P. Kinoshita
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+/**
+ * See JENKINS-75760.
+ *
+ * @since 2.8.7
+ */
+package org.biouno.unochoice.issue75760;

--- a/src/test/java/org/biouno/unochoice/issue75760/package-info.java
+++ b/src/test/java/org/biouno/unochoice/issue75760/package-info.java
@@ -1,7 +1,7 @@
 /*
  * The MIT License (MIT)
  *
- * Copyright (c) 2014-2025 Ioannis Moutsatsos, Bruno P. Kinoshita
+ * Copyright (c) 2014-2026 Ioannis Moutsatsos, Bruno P. Kinoshita
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -23,8 +23,8 @@
  */
 
 /**
- * See JENKINS-75760.
+ * Tests for default checkbox values. See JENKINS-75760.
  *
- * @since 2.8.7
+ * @since 2.8.10
  */
 package org.biouno.unochoice.issue75760;


### PR DESCRIPTION
This PR refer to the JENKINS-75760 issue (https://github.com/jenkinsci/active-choices-plugin/issues/901).

Closes #901

### Testing done

I wrote some tests in order to correct the misbehavior by TDD approach.  
One test is with a sandbox script, one with a trusted script and the last one with an untrusted script.  
All these tests should return an empty parameter value, as all checkbox should be unchecked by default) but all of them return the value of the first checkbox.

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed