### PR TITLE
JENKINS-75644 Cache project resolution after UUID fallback

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@
 - Bump ts-loader from 9.5.4 to 9.5.7
 - Bump webpack from 5.105.4 to 5.106.2
 - Bump webpack-cli from 7.0.1 to 7.0.2
+- #897 JENKINS-75644 Cache project resolution after UUID fallback (thanks @tzachs)
 
 ## Version 2.8.9 (2026/02/16)
 

--- a/src/main/java/org/biouno/unochoice/AbstractScriptableParameter.java
+++ b/src/main/java/org/biouno/unochoice/AbstractScriptableParameter.java
@@ -99,6 +99,14 @@ public abstract class AbstractScriptableParameter extends AbstractUnoChoiceParam
      */
     private final String projectFullName;
     /**
+     * Cached project name resolved after construction, used to avoid repeated project scans.
+     */
+    private volatile String projectNameCache;
+    /**
+     * Cached project full name resolved after construction, used to avoid repeated project scans.
+     */
+    private volatile String projectFullNameCache;
+    /**
      * A cache for the default parameter value to avoid JENKINS-76298
      */
     private String cachedDefaultValue;
@@ -146,6 +154,16 @@ public abstract class AbstractScriptableParameter extends AbstractUnoChoiceParam
         this.projectFullName = projectFullName;
     }
 
+    private void rememberProject(AbstractItem project) {
+        if (project != null) {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.fine(String.format("Caching project '%s' for parameter '%s'", project.getFullName(), getName()));
+            }
+            this.projectNameCache = project.getName();
+            this.projectFullNameCache = project.getFullName();
+        }
+    }
+
     protected AbstractItem detectProject() {
         final StaplerRequest2 currentRequest = Stapler.getCurrentRequest2();
         if (currentRequest != null) {
@@ -189,24 +207,59 @@ public abstract class AbstractScriptableParameter extends AbstractUnoChoiceParam
 
         // First, if the project name is set, we then find the project by its name, and inject into the map
         Job<?, ?> project = null;
-        if (StringUtils.isNotBlank(this.projectFullName)) {
+        final String resolvedProjectFullName = StringUtils.defaultIfBlank(this.projectFullNameCache, this.projectFullName);
+        final String resolvedProjectName = StringUtils.defaultIfBlank(this.projectNameCache, this.projectName);
+        if (StringUtils.isNotBlank(resolvedProjectFullName)) {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.fine(String.format("Attempting project resolution by full name '%s' for parameter '%s'", resolvedProjectFullName, getName()));
+            }
             // First try full name if exists
-            project = Jenkins.get().getItemByFullName(this.projectFullName, Project.class);
-        } else if (StringUtils.isNotBlank(this.projectName)) {
+            project = Jenkins.get().getItemByFullName(resolvedProjectFullName, Project.class);
+            if (project != null) {
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.fine(String.format("Resolved project by full name '%s' for parameter '%s'", resolvedProjectFullName, getName()));
+                }
+                rememberProject(project);
+            }
+        } else if (StringUtils.isNotBlank(resolvedProjectName)) {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.fine(String.format("Attempting project resolution by name '%s' for parameter '%s'", resolvedProjectName, getName()));
+            }
             // next we try to get the item given its name, which is more efficient
-            project = Utils.getProjectByName(this.projectName);
+            project = Utils.getProjectByName(resolvedProjectName);
+            if (project != null) {
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.fine(String.format("Resolved project by name '%s' for parameter '%s'", resolvedProjectName, getName()));
+                }
+                rememberProject(project);
+            }
         } else {
+            if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.fine(String.format("No cached project name available for parameter '%s'; attempting request-based project detection", getName()));
+            }
             // check whether the current thread has enough info to detect project
             // i.e. it serves a web request to the project build page
             final AbstractItem parentItem = detectProject();
             if (parentItem != null) {
                 project = Jenkins.get().getItemByFullName(parentItem.getFullName(), Job.class);
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.fine(String.format("Resolved project from current request '%s' for parameter '%s'", parentItem.getFullName(), getName()));
+                }
+                rememberProject(parentItem);
+            } else if (LOGGER.isLoggable(Level.FINE)) {
+                LOGGER.fine(String.format("Request-based project detection did not find a project for parameter '%s'", getName()));
             }
         }
         // Last chance, if we were unable to get project from name and full name, try uuid
         if (project == null) {
             // otherwise, in case we don't have the item name, we iterate looking for a job that uses this UUID
             project = Utils.findProjectByParameterUUID(this.getRandomName());
+            if (project != null) {
+                if (LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.fine(String.format("Resolved project by parameter UUID '%s' for parameter '%s'", this.getRandomName(), getName()));
+                }
+                rememberProject(project);
+            }
         }
         if (project != null) {
             helperParameters.put(JENKINS_PROJECT_VARIABLE_NAME, project);

--- a/src/test/java/org/biouno/unochoice/BaseUiTest.java
+++ b/src/test/java/org/biouno/unochoice/BaseUiTest.java
@@ -41,11 +41,16 @@ import org.openqa.selenium.chrome.ChromeOptions;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.WebDriverWait;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.time.Duration;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Supplier;
+import java.util.stream.Stream;
 
 @WithJenkins
 public abstract class BaseUiTest {
@@ -54,6 +59,7 @@ public abstract class BaseUiTest {
 
     protected WebDriver driver;
     protected WebDriverWait wait;
+    private static String ciBrowserBinary;
 
     protected static boolean isCi() {
         return StringUtils.isNotBlank(System.getenv("CI"));
@@ -64,14 +70,12 @@ public abstract class BaseUiTest {
     @BeforeAll
     public static void setUpClass() {
         if (isCi()) {
-            // The browserVersion needs to match what is provided by the Jenkins Infrastructure
-            // If you see an exception like this:
-            //
-            // org.openqa.selenium.SessionNotCreatedException: Could not start a new session. Response code 500. Message: session not created: This version of ChromeDriver only supports Chrome version 114
-            // Current browser version is 112.0.5615.49 with binary path /usr/bin/chromium-browser
-            //
-            // Then that means you need to update the version here to match the current browser version.
-            WebDriverManager.chromedriver().browserVersion("112").setup();
+            ciBrowserBinary = findCiBrowserBinary();
+            if (StringUtils.isNotBlank(ciBrowserBinary)) {
+                WebDriverManager.chromedriver().browserBinary(ciBrowserBinary).setup();
+            } else {
+                WebDriverManager.chromedriver().setup();
+            }
         } else {
             WebDriverManager.chromedriver().setup();
         }
@@ -80,13 +84,52 @@ public abstract class BaseUiTest {
     @BeforeEach
     public void setUp(JenkinsRule j) {
         this.j = j;
+        final ChromeOptions options = new ChromeOptions();
         if (isCi()) {
-            driver = new ChromeDriver(new ChromeOptions().addArguments("--headless", "--disable-dev-shm-usage", "--no-sandbox"));
-        } else {
-            driver = new ChromeDriver(new ChromeOptions());
+            options.addArguments("--headless", "--disable-dev-shm-usage", "--no-sandbox");
+            if (StringUtils.isNotBlank(ciBrowserBinary)) {
+                options.setBinary(ciBrowserBinary);
+            }
         }
+        driver = new ChromeDriver(options);
         wait = new WebDriverWait(driver, MAX_WAIT);
         driver.manage().window().setSize(new Dimension(2560, 1440));
+    }
+
+    private static String findCiBrowserBinary() {
+        String configuredBinary = System.getProperty("ui.chrome.binary");
+        if (StringUtils.isBlank(configuredBinary)) {
+            configuredBinary = System.getenv("CHROME_BIN");
+        }
+        if (StringUtils.isNotBlank(configuredBinary) && Files.isExecutable(Path.of(configuredBinary))) {
+            return configuredBinary;
+        }
+
+        final Path playwrightCache = Path.of(System.getProperty("user.home"), ".cache", "ms-playwright");
+        if (!Files.isDirectory(playwrightCache)) {
+            return null;
+        }
+
+        try (Stream<Path> paths = Files.walk(playwrightCache, 3)) {
+            return paths
+                    .filter(Files::isRegularFile)
+                    .filter(Files::isExecutable)
+                    .filter(BaseUiTest::isChromeExecutable)
+                    .sorted(Comparator.comparing(Path::toString).reversed())
+                    .map(Path::toString)
+                    .findFirst()
+                    .orElse(null);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to scan Playwright browser cache", e);
+        }
+    }
+
+    private static boolean isChromeExecutable(Path path) {
+        final String fileName = path.getFileName().toString();
+        return "headless_shell".equals(fileName)
+                || "chrome".equals(fileName)
+                || "chromium".equals(fileName)
+                || "chromium-browser".equals(fileName);
     }
 
     @AfterEach

--- a/src/test/java/org/biouno/unochoice/BaseUiTest.java
+++ b/src/test/java/org/biouno/unochoice/BaseUiTest.java
@@ -109,6 +109,12 @@ public abstract class BaseUiTest {
             return configuredBinary;
         }
 
+        for (Path commonBinary : commonLinuxBrowserBinaries()) {
+            if (Files.exists(commonBinary)) {
+                return commonBinary.toString();
+            }
+        }
+
         final List<Path> searchRoots = browserSearchRoots();
         for (Path searchRoot : searchRoots) {
             if (Files.isDirectory(searchRoot)) {
@@ -122,21 +128,40 @@ public abstract class BaseUiTest {
         System.out.println("No CI Chrome binary found. Checked " + searchRoots
                 + ", user.home=" + System.getProperty("user.home")
                 + ", HOME=" + System.getenv("HOME")
-                + ", CHROME_BIN=" + System.getenv("CHROME_BIN"));
+                + ", CHROME_BIN=" + System.getenv("CHROME_BIN")
+                + ", PLAYWRIGHT_BROWSERS_PATH=" + System.getenv("PLAYWRIGHT_BROWSERS_PATH"));
         return null;
     }
 
     private static List<Path> browserSearchRoots() {
         final Set<Path> searchRoots = new LinkedHashSet<>();
+        addPath(searchRoots, System.getenv("PLAYWRIGHT_BROWSERS_PATH"));
         addPlaywrightCache(searchRoots, System.getProperty("user.home"));
         addPlaywrightCache(searchRoots, System.getenv("HOME"));
         searchRoots.add(Path.of("/home/jenkins/.cache/ms-playwright"));
+        searchRoots.add(Path.of("/cache/ms-playwright"));
+        searchRoots.add(Path.of("/cache"));
         return new ArrayList<>(searchRoots);
+    }
+
+    private static List<Path> commonLinuxBrowserBinaries() {
+        return List.of(
+                Path.of("/usr/bin/google-chrome"),
+                Path.of("/usr/bin/google-chrome-stable"),
+                Path.of("/usr/bin/chromium"),
+                Path.of("/usr/bin/chromium-browser"),
+                Path.of("/opt/google/chrome/chrome"));
     }
 
     private static void addPlaywrightCache(Set<Path> searchRoots, String homeDirectory) {
         if (StringUtils.isNotBlank(homeDirectory)) {
             searchRoots.add(Path.of(homeDirectory, ".cache", "ms-playwright"));
+        }
+    }
+
+    private static void addPath(Set<Path> searchRoots, String path) {
+        if (StringUtils.isNotBlank(path)) {
+            searchRoots.add(Path.of(path));
         }
     }
 

--- a/src/test/java/org/biouno/unochoice/BaseUiTest.java
+++ b/src/test/java/org/biouno/unochoice/BaseUiTest.java
@@ -46,9 +46,12 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.text.MessageFormat;
 import java.time.Duration;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
 
@@ -60,6 +63,7 @@ public abstract class BaseUiTest {
     protected WebDriver driver;
     protected WebDriverWait wait;
     private static String ciBrowserBinary;
+    private static final int PLAYWRIGHT_BROWSER_SCAN_DEPTH = 8;
 
     protected static boolean isCi() {
         return StringUtils.isNotBlank(System.getenv("CI"));
@@ -101,26 +105,52 @@ public abstract class BaseUiTest {
         if (StringUtils.isBlank(configuredBinary)) {
             configuredBinary = System.getenv("CHROME_BIN");
         }
-        if (StringUtils.isNotBlank(configuredBinary) && Files.isExecutable(Path.of(configuredBinary))) {
+        if (StringUtils.isNotBlank(configuredBinary) && Files.exists(Path.of(configuredBinary))) {
             return configuredBinary;
         }
 
-        final Path playwrightCache = Path.of(System.getProperty("user.home"), ".cache", "ms-playwright");
-        if (!Files.isDirectory(playwrightCache)) {
-            return null;
+        final List<Path> searchRoots = browserSearchRoots();
+        for (Path searchRoot : searchRoots) {
+            if (Files.isDirectory(searchRoot)) {
+                final String detectedBinary = findChromeExecutable(searchRoot);
+                if (StringUtils.isNotBlank(detectedBinary)) {
+                    return detectedBinary;
+                }
+            }
         }
 
-        try (Stream<Path> paths = Files.walk(playwrightCache, 3)) {
+        System.out.println("No CI Chrome binary found. Checked " + searchRoots
+                + ", user.home=" + System.getProperty("user.home")
+                + ", HOME=" + System.getenv("HOME")
+                + ", CHROME_BIN=" + System.getenv("CHROME_BIN"));
+        return null;
+    }
+
+    private static List<Path> browserSearchRoots() {
+        final Set<Path> searchRoots = new LinkedHashSet<>();
+        addPlaywrightCache(searchRoots, System.getProperty("user.home"));
+        addPlaywrightCache(searchRoots, System.getenv("HOME"));
+        searchRoots.add(Path.of("/home/jenkins/.cache/ms-playwright"));
+        return new ArrayList<>(searchRoots);
+    }
+
+    private static void addPlaywrightCache(Set<Path> searchRoots, String homeDirectory) {
+        if (StringUtils.isNotBlank(homeDirectory)) {
+            searchRoots.add(Path.of(homeDirectory, ".cache", "ms-playwright"));
+        }
+    }
+
+    private static String findChromeExecutable(Path searchRoot) {
+        try (Stream<Path> paths = Files.walk(searchRoot, PLAYWRIGHT_BROWSER_SCAN_DEPTH)) {
             return paths
                     .filter(Files::isRegularFile)
-                    .filter(Files::isExecutable)
                     .filter(BaseUiTest::isChromeExecutable)
                     .sorted(Comparator.comparing(Path::toString).reversed())
                     .map(Path::toString)
                     .findFirst()
                     .orElse(null);
         } catch (IOException e) {
-            throw new IllegalStateException("Failed to scan Playwright browser cache", e);
+            throw new IllegalStateException("Failed to scan browser cache " + searchRoot, e);
         }
     }
 

--- a/src/test/java/org/biouno/unochoice/BaseUiTest.java
+++ b/src/test/java/org/biouno/unochoice/BaseUiTest.java
@@ -182,6 +182,7 @@ public abstract class BaseUiTest {
     private static boolean isChromeExecutable(Path path) {
         final String fileName = path.getFileName().toString();
         return "headless_shell".equals(fileName)
+                || "chrome-headless-shell".equals(fileName)
                 || "chrome".equals(fileName)
                 || "chromium".equals(fileName)
                 || "chromium-browser".equals(fileName);

--- a/src/test/java/org/biouno/unochoice/UiAcceptanceTest.java
+++ b/src/test/java/org/biouno/unochoice/UiAcceptanceTest.java
@@ -60,7 +60,8 @@ class UiAcceptanceTest extends BaseUiTest {
 
         wait.withMessage(() -> "The help text should have been displayed").until(d -> helpTextDiv.isDisplayed());
 
-        assertTrue(helpTextDiv.getText().startsWith("This is a simple parameter"));
+        wait.withMessage(() -> "The help text should have loaded. Had: " + helpTextDiv.getText())
+                .until(d -> helpTextDiv.getText().startsWith("This is a simple parameter"));
     }
 
     @LocalData

--- a/src/test/java/org/biouno/unochoice/issue_performance/TestProjectResolutionCaching.java
+++ b/src/test/java/org/biouno/unochoice/issue_performance/TestProjectResolutionCaching.java
@@ -1,0 +1,96 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014-2026 Ioannis Moutsatsos, Bruno P. Kinoshita
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package org.biouno.unochoice.issue_performance;
+
+import hudson.model.Descriptor;
+import hudson.model.FreeStyleProject;
+import hudson.model.ParametersDefinitionProperty;
+import org.biouno.unochoice.AbstractScriptableParameter;
+import org.biouno.unochoice.AbstractUnoChoiceParameter;
+import org.biouno.unochoice.ChoiceParameter;
+import org.biouno.unochoice.model.GroovyScript;
+import org.jenkinsci.plugins.scriptsecurity.sandbox.groovy.SecureGroovyScript;
+import org.jenkinsci.plugins.scriptsecurity.scripts.ScriptApproval;
+import org.jenkinsci.plugins.scriptsecurity.scripts.languages.GroovyLanguage;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+import org.jvnet.hudson.test.junit.jupiter.WithJenkins;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@WithJenkins
+class TestProjectResolutionCaching {
+
+    private JenkinsRule j;
+
+    private static final String SCRIPT_LIST = "return [jenkinsProject.getFullName()]";
+    private static final String FALLBACK_SCRIPT_LIST = "return ['EMPTY!']";
+
+    @BeforeEach
+    void setUp(JenkinsRule j) {
+        this.j = j;
+        ScriptApproval.get().preapprove(SCRIPT_LIST, GroovyLanguage.get());
+        ScriptApproval.get().preapprove(FALLBACK_SCRIPT_LIST, GroovyLanguage.get());
+    }
+
+    @Test
+    void cachesResolvedProjectNameAfterUuidLookup() throws IOException, Descriptor.FormException, ReflectiveOperationException {
+        FreeStyleProject project = j.createProject(FreeStyleProject.class, "performance-test");
+        ChoiceParameter parameter = new ChoiceParameter(
+                "param",
+                "description",
+                "random-name",
+                new GroovyScript(
+                        new SecureGroovyScript(SCRIPT_LIST, false, null),
+                        new SecureGroovyScript(FALLBACK_SCRIPT_LIST, false, null)
+                ),
+                AbstractUnoChoiceParameter.PARAMETER_TYPE_SINGLE_SELECT,
+                false,
+                1
+        );
+        project.addProperty(new ParametersDefinitionProperty(parameter));
+
+        assertNull(getField(parameter, "projectFullName"));
+        assertNull(getField(parameter, "projectFullNameCache"));
+
+        parameter.getChoices();
+
+        assertNull(getField(parameter, "projectFullName"));
+        assertNull(getField(parameter, "projectName"));
+        assertEquals(project.getFullName(), getField(parameter, "projectFullNameCache"));
+        assertEquals(project.getName(), getField(parameter, "projectNameCache"));
+    }
+
+    private static Object getField(Object target, String fieldName) throws ReflectiveOperationException {
+        Field field = AbstractScriptableParameter.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(target);
+    }
+}


### PR DESCRIPTION
Closes #897 

Cache project resolution after UUID fallback to avoid repeated scans when rendering Uno-Choice parameters.

When an `AbstractScriptableParameter` cannot determine its owning job from the current request or from a known project name/full name, it falls back to resolving the job by the parameter UUID. This change caches the resolved project name and full name after that fallback succeeds, so subsequent evaluations can use direct lookup instead of scanning Jenkins items again.

A focused test was added in [`TestProjectResolutionCaching.java`](/Users/tzach/personal/active-choices-plugin/src/test/java/org/biouno/unochoice/issue_performance/TestProjectResolutionCaching.java). It verifies that the parameter starts with `projectName` and `projectFullName` unset, that calling `getChoices()` forces project resolution through the UUID path, and that the new `projectNameCache` and `projectFullNameCache` fields are populated afterward.

### Testing done

- Added automated test coverage in [`TestProjectResolutionCaching.java`](/Users/tzach/personal/active-choices-plugin/src/test/java/org/biouno/unochoice/issue_performance/TestProjectResolutionCaching.java) for the new caching behavior after UUID-based project resolution.
- Verified by inspection that the test exercises the new `rememberProject(...)` path in [`AbstractScriptableParameter.java`](/Users/tzach/personal/active-choices-plugin/src/main/java/org/biouno/unochoice/AbstractScriptableParameter.java).
- Local test execution was not completed in this environment because Maven is not installed here (`mvn: command not found`).

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira: [JENKINS-75644](https://issues.jenkins.io/browse/JENKINS-75644) [#897](https://github.com/jenkinsci/active-choices-plugin/issues/897)
- [x] Link to relevant pull requests, esp. upstream and downstream changes: https://github.com/jenkinsci/active-choices-plugin/pull/962
- [x] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
