### PR TITLE
Avoid trailing commas in reactive reference values

### DIFF
--- a/src/main/java/org/biouno/unochoice/AbstractUnoChoiceParameter.java
+++ b/src/main/java/org/biouno/unochoice/AbstractUnoChoiceParameter.java
@@ -168,13 +168,7 @@ public abstract class AbstractUnoChoiceParameter extends SimpleParameterDefiniti
             final JSONObject parameterJsonModel = new JSONObject(false);
             final Object value = json.get("value");
             final Object name = json.get("name");
-            final String valueAsText;
-
-            if (JSONUtils.isArray(value)) {
-                valueAsText = ((JSONArray) value).join(",", true);
-            } else {
-                valueAsText = (value == null) ? "" : String.valueOf(value);
-            }
+            final String valueAsText = getSubmittedValueAsText(value);
 
             parameterJsonModel.put("name",  name);
             parameterJsonModel.put("value", valueAsText);
@@ -183,6 +177,18 @@ public abstract class AbstractUnoChoiceParameter extends SimpleParameterDefiniti
             parameterValue.setDescription(getDescription());
             return parameterValue;
         }
+    }
+
+    private static String getSubmittedValueAsText(Object value) {
+        if (!JSONUtils.isArray(value)) {
+            return (value == null) ? "" : String.valueOf(value);
+        }
+
+        JSONArray values = JSONArray.fromObject(value);
+        while (values.size() > 1 && "".equals(String.valueOf(values.get(values.size() - 1)))) {
+            values.remove(values.size() - 1);
+        }
+        return values.join(",", true);
     }
 
     /**

--- a/src/test/java/org/biouno/unochoice/TestAbstractUnoChoiceParameter.java
+++ b/src/test/java/org/biouno/unochoice/TestAbstractUnoChoiceParameter.java
@@ -40,6 +40,7 @@ import org.mockito.Mockito;
 
 import hudson.model.ParameterValue;
 import hudson.model.StringParameterValue;
+import net.sf.json.JSONArray;
 import net.sf.json.JSONObject;
 
 /**
@@ -75,6 +76,31 @@ class TestAbstractUnoChoiceParameter {
         Mockito.when(request.bindJSON(StringParameterValue.class, json)).thenReturn((StringParameterValue) value);
 
         value = param.createValue(request, json);
+
+        assertEquals("value", value.getValue().toString());
+    }
+
+    @Test
+    void createValueIgnoresBlankTrailingValueFromDynamicReferenceParameters() throws Descriptor.FormException {
+        GroovyScript script = new GroovyScript(new SecureGroovyScript(SCRIPT, Boolean.FALSE, null),
+                new SecureGroovyScript(FALLBACK_SCRIPT, Boolean.FALSE, null));
+        ChoiceParameter param = new ChoiceParameter("name", "description", "some-random-name", script, "choiceType",
+                true, 0);
+
+        JSONObject json = new JSONObject();
+        json.put("name", "name");
+        json.put("value", JSONArray.fromObject(new String[] {"value", ""}));
+
+        StaplerRequest2 request = Mockito.mock(StaplerRequest2.class);
+        Mockito.when(request.bindJSON(Mockito.eq(StringParameterValue.class), Mockito.any(JSONObject.class)))
+                .thenAnswer(invocation -> {
+                    JSONObject parameterJsonModel = invocation.getArgument(1);
+                    return new StringParameterValue(
+                            parameterJsonModel.getString("name"),
+                            parameterJsonModel.getString("value"));
+                });
+
+        ParameterValue value = param.createValue(request, json);
 
         assertEquals("value", value.getValue().toString());
     }


### PR DESCRIPTION
Reactive Reference parameters can submit their intended value together with the plugin-injected blank value field. The array was joined directly, producing values such as `autoinstall,` in Jenkins builds.

Trim trailing blank array values before serializing the submitted parameter.

Tested with:
- `mvn -B -Dtest=TestAbstractUnoChoiceParameter test`